### PR TITLE
Fix extra fields throwing errors when added to columns list

### DIFF
--- a/tap_bing_ads/__init__.py
+++ b/tap_bing_ads/__init__.py
@@ -670,8 +670,12 @@ def sync_report(client, account_id, report_stream):
     scope.AccountIds = {'long': [account_id]}
     report_request.Scope = scope
 
+    excluded_fields = ['GregorianDate', '_sdc_report_datetime']
+    if report_name in reports.EXTRA_FIELDS:
+        excluded_fields += reports.EXTRA_FIELDS[report_name]
+
     selected_fields = get_selected_fields(report_stream,
-                                          exclude=['GregorianDate', '_sdc_report_datetime'])
+                                          exclude=excluded_fields)
     selected_fields.append('TimePeriod')
 
     report_columns = client.factory.create('ArrayOf{}Column'.format(report_name))


### PR DESCRIPTION
The EXTRA_FIELDS constant maps reports to lists of columns that are not selectable and always included in certain reports. They are included in the catalog (automatic) and the output schema, so that the client can expect them. However, they were being passed to the Bing Ads API in the list of selected report columns, which was causing an error.

Closes https://github.com/singer-io/tap-bing-ads/issues/7