### PR TITLE
Replace commas when converting to float

### DIFF
--- a/tap_bing_ads/__init__.py
+++ b/tap_bing_ads/__init__.py
@@ -578,7 +578,7 @@ def type_report_row(row):
             if _type == 'integer':
                 value = int(value)
             elif _type == 'number':
-                value = float(value.replace('%', ''))
+                value = float(value.replace('%', '').replace(',', ''))
             elif _type in ['date', 'datetime']:
                 value = arrow.get(value).isoformat()
 


### PR DESCRIPTION
Zuora returns Strings that can also contain decimal points. For example: 

```
tap_bing_ads/__init__.py", line 581, in type_report_row
     value = float(value.replace('%', ''))
ValueError: could not convert string to float: '1,234.00'
```
