### PR TITLE
PauseReason has a type of unsignedByte

### DIFF
--- a/tap_bing_ads/__init__.py
+++ b/tap_bing_ads/__init__.py
@@ -116,7 +116,7 @@ def xml_to_json_type(xml_type):
         return 'boolean'
     if xml_type in ['decimal', 'float', 'double']:
         return 'number'
-    if xml_type in ['long', 'int']:
+    if xml_type in ['long', 'int', 'unsignedByte']:
         return 'integer'
 
     return 'string'


### PR DESCRIPTION
PauseReason was getting a schema of ["null", "string"] 

> A flag value that indicates who paused the account. The following are the possible values:
>1 - The user paused the account.
>2 - The billing service paused the account.
>4 - The user and billing service paused the account.
> unsignedByte

 https://docs.microsoft.com/en-us/bingads/customer-management-service/account?view=bingads-11

Add that type to the block that gives us an integer schema.