### PR TITLE
Adding the audience report to reports.py

### DIFF
--- a/tap_bing_ads/reports.py
+++ b/tap_bing_ads/reports.py
@@ -6,7 +6,8 @@ REPORT_WHITELIST = [
     'AgeGenderDemographicReport',
     'SearchQueryPerformanceReport',
     'CampaignPerformanceReport',
-    'GoalsAndFunnelsReport'
+    'GoalsAndFunnelsReport',
+    'AudiencePerformanceReport'
 ]
 
 REPORT_REQUIRED_FIELDS = ['_sdc_report_datetime', 'AccountId', 'GregorianDate']
@@ -19,7 +20,8 @@ REPORT_SPECIFIC_REQUIRED_FIELDS = {
         'AgeGroup',
         'Gender'
     ],
-    'SearchQueryPerformanceReport': ['SearchQuery']
+    'SearchQueryPerformanceReport': ['SearchQuery'],
+    'AudiencePerformanceReport': ['AudienceId']
 }
 
 ALIASES = {


### PR DESCRIPTION
I found the required columns here: 
https://docs.microsoft.com/en-us/bingads/reporting-service/audienceperformancereportcolumn?view=bingads-12#requiredcolumns

I just need the following columns:
Account name
Audience name
Audience ID
Campaign name
Ad group
Impressions
Clicks
Spend
Conversions


Can someone help me test?
