### PR TITLE
Update API to v13

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     py_modules=['tap_bingads'],
     install_requires=[
         'arrow==0.12.0',
-        'bingads==11.12.6',
+        'bingads==13.0.1',
         'requests==2.20.0',
         'singer-python==5.0.4',
         'stringcase==1.2.0'

--- a/tap_bing_ads/__init__.py
+++ b/tap_bing_ads/__init__.py
@@ -83,7 +83,7 @@ def log_service_call(service_method):
 
 class CustomServiceClient(ServiceClient):
     def __init__(self, name, **kwargs):
-        return super().__init__(name, 'v12', **kwargs)
+        return super().__init__(name, 'v13', **kwargs)
 
     def __getattr__(self, name):
         service_method = super(CustomServiceClient, self).__getattr__(name)
@@ -814,7 +814,6 @@ def build_report_request(client, account_id, report_stream, report_name,
     report_request = client.factory.create('{}Request'.format(report_name))
     report_request.Format = 'Csv'
     report_request.Aggregation = 'Daily'
-    report_request.Language = 'English'
     report_request.ExcludeReportHeader = True
     report_request.ExcludeReportFooter = True
 


### PR DESCRIPTION
# Description of change

As I linked to in Issue #35 v12 of the Bing Ads API was deprecated on 31st October. I believe that the only significant change from the perspective of this project is the removal of the Languages field at the top level of the reports request. This has been moved to a report level filter on some reports.

Please do let me know if I missed any other breaking changes, I have tested that this change does still allow data to be pulled for at least a subset of reports. 

# Manual QA steps
 - Check it works
 
# Risks
 - It doesn't work
 
# Rollback steps
 - revert this branch
