### PR TITLE
Update to api v13

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     py_modules=['tap_bingads'],
     install_requires=[
         'arrow==0.12.0',
-        'bingads==11.12.6',
+        'bingads==12.13.1',
         'requests==2.20.0',
         'singer-python==5.9.0',
         'stringcase==1.2.0',

--- a/tap_bing_ads/__init__.py
+++ b/tap_bing_ads/__init__.py
@@ -609,9 +609,15 @@ def type_report_row(row):
         if value is not None and field_name in reports.REPORTING_FIELD_TYPES:
             _type = reports.REPORTING_FIELD_TYPES[field_name]
             if _type == 'integer':
-                value = int(value.replace(',', ''))
+                if value == '--':
+                    value = 0
+                else:
+                    value = int(value.replace(',', ''))
             elif _type == 'number':
-                value = float(value.replace('%', '').replace(',', ''))
+                if value == '--':
+                    value = 0.0
+                else:
+                    value = float(value.replace('%', '').replace(',', ''))
             elif _type in ['date', 'datetime']:
                 value = arrow.get(value).isoformat()
 
@@ -826,7 +832,6 @@ def build_report_request(client, account_id, report_stream, report_name,
     report_request = client.factory.create('{}Request'.format(report_name))
     report_request.Format = 'Csv'
     report_request.Aggregation = 'Daily'
-    report_request.Language = 'English'
     report_request.ExcludeReportHeader = True
     report_request.ExcludeReportFooter = True
 

--- a/tap_bing_ads/__init__.py
+++ b/tap_bing_ads/__init__.py
@@ -88,7 +88,7 @@ def log_service_call(service_method, account_id):
 
 class CustomServiceClient(ServiceClient):
     def __init__(self, name, **kwargs):
-        return super().__init__(name, 'v12', **kwargs)
+        return super().__init__(name, 'v13', **kwargs)
 
     def __getattr__(self, name):
         service_method = super(CustomServiceClient, self).__getattr__(name)

--- a/tap_bing_ads/reports.py
+++ b/tap_bing_ads/reports.py
@@ -3,7 +3,7 @@ REPORT_WHITELIST = [
     'AdPerformanceReport',
     'AdGroupPerformanceReport',
     'GeographicPerformanceReport',
-    'AgeGenderDemographicReport',
+    'AgeGenderAudienceReport',
     'SearchQueryPerformanceReport',
     'CampaignPerformanceReport',
     'GoalsAndFunnelsReport',


### PR DESCRIPTION
# Description of change
bing-ads api v12 has been sunset so the tap needs to be updated to use api v13

The python sdk should be updated to v12.13.1 since v12.13.2 uses the Microsoft Identity Platform Endpoint by default, which we will move to in the future.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
