### PR TITLE
Only resume requests from STATE if they are non-null

### DIFF
--- a/tap_bing_ads/__init__.py
+++ b/tap_bing_ads/__init__.py
@@ -789,9 +789,8 @@ async def sync_report_interval(client, account_id, report_stream,
 def get_report_request_id(client, account_id, report_stream, report_name,
                           start_date, end_date, state_key, force_refresh=False):
 
-    if not force_refresh:
-        saved_request_id = singer.get_bookmark(STATE, state_key, 'request_id')
-
+    saved_request_id = singer.get_bookmark(STATE, state_key, 'request_id')
+    if not force_refresh and saved_request_id is not None:
         LOGGER.info(
             'Resuming polling for account {}: {}'
             .format(account_id, report_name)


### PR DESCRIPTION
# Description of change
This is a large inefficiency when many account IDs are selected. Each one, per report, will try to resume with a null request ID, even though that is guaranteed to fail.

This PR adds a check to only resume from a request ID that is not null.

# Manual QA steps
 - Manually confirmed that it's not making many requests for null IDs anymore, and instead starting new reports.
 
# Risks
 - Medium, it's rather highly used code, but it's a pretty explicit change.
 
# Rollback steps
 - revert this branch and bump the patch version number
