### PR TITLE
add retry to report retrieval

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,9 @@ setup(
         'arrow==0.12.0',
         'bingads==11.12.6',
         'requests==2.20.0',
-        'singer-python==5.0.4',
-        'stringcase==1.2.0'
+        'singer-python==5.9.0',
+        'stringcase==1.2.0',
+        'backoff==1.8.0',
     ],
     extras_require={
         'dev': [


### PR DESCRIPTION
# Description of change
Add a retry (up to 5 times) for connection time outs during report retrieval

# Manual QA steps
Could not reproduce connection time out locally, so manually tested by throwing exception and ensuring the retry logic worked correctly
 
# Risks
 None
 
# Rollback steps
 - revert this branch
