### PR TITLE
bump to v2.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.0.8
+  * Updates bing-ads dependency to support v13 and implements the version migration [#37](https://github.com/singer-io/tap-bing-ads/pull/37)
+
 ## 2.0.7
   * Add logging when client is created, service message is sent, exception is caught [#41](https://github.com/singer-io/tap-bing-ads/pull/41)
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='tap-bing-ads',
-    version="2.0.7",
+    version="2.0.8",
     description='Singer.io tap for extracting data from the Bing Ads API',
     author='Stitch',
     url='http://singer.io',


### PR DESCRIPTION
# Description of change

Bumps version to 2.0.8

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
