### PR TITLE
Find additional Campaign types

### DIFF
--- a/tap_bing_ads/__init__.py
+++ b/tap_bing_ads/__init__.py
@@ -527,7 +527,8 @@ def sync_accounts_stream(account_ids, catalog_item):
     singer.write_state(STATE)
 
 def sync_campaigns(client, account_id, selected_streams):
-    response = client.GetCampaignsByAccountId(AccountId=account_id)
+    # CampaignType defaults to 'Search', but there are other types of campaigns
+    response = client.GetCampaignsByAccountId(AccountId=account_id, CampaignType='Search Shopping DynamicSearchAds')
     response_dict = sobject_to_dict(response)
     if 'Campaign' in response_dict:
         campaigns = response_dict['Campaign']


### PR DESCRIPTION
# Description of change

The SOAP request for retrieving a campaign by account id takes a CampaignType parameter that defaults to only "Search." There are newer (and other) types of Campaigns that we should be searching for. The syntax here is a space separated list of the types:

https://docs.microsoft.com/en-us/advertising/campaign-management-service/getcampaignsbyaccountid?view=bingads-13

# Manual QA steps
 - Confirmed that an Account with multiple campaign types retrieves them all
 
# Risks
 - Permissions error?
 
# Rollback steps
 - revert this branch
