### PR TITLE
Update Field Exclusions

### DIFF
--- a/tap_bing_ads/exclusions.py
+++ b/tap_bing_ads/exclusions.py
@@ -14,7 +14,11 @@ EXCLUSIONS = {
             'ImpressionLostToBudgetPercent',
             'ImpressionLostToExpectedCtrPercent',
             'ImpressionLostToRankPercent',
-            'ImpressionSharePercent'
+            'ImpressionSharePercent',
+            'TopImpressionRatePercent',
+            'TopImpressionShareLostToBudgetPercent',
+            'TopImpressionShareLostToRankPercent',
+            'TopImpressionSharePercent'
         ]
     },
     'AdGroupPerformanceReport': {
@@ -32,7 +36,11 @@ EXCLUSIONS = {
             'ImpressionLostToBudgetPercent',
             'ImpressionLostToExpectedCtrPercent',
             'ImpressionLostToRankPercent',
-            'ImpressionSharePercent'
+            'ImpressionSharePercent',
+            'TopImpressionRatePercent',
+            'TopImpressionShareLostToBudgetPercent',
+            'TopImpressionShareLostToRankPercent',
+            'TopImpressionSharePercent'
         ]
     },
     'CampaignPerformanceReport': {
@@ -53,7 +61,11 @@ EXCLUSIONS = {
             'ImpressionLostToBudgetPercent',
             'ImpressionLostToExpectedCtrPercent',
             'ImpressionLostToRankPercent',
-            'ImpressionSharePercent'
+            'ImpressionSharePercent',
+            'TopImpressionRatePercent',
+            'TopImpressionShareLostToBudgetPercent',
+            'TopImpressionShareLostToRankPercent',
+            'TopImpressionSharePercent'
         ]
     },
     'ProductDimensionPerformanceReport': {


### PR DESCRIPTION
# Description of change
Microsoft Advertising reporting has the concept of field exclusions, as detailed in their docs [here](https://docs.microsoft.com/en-us/advertising/guides/reports?view=bingads-13#columnrestrictions).

We've had users seeing the following error despite their field selections obeying the column restrictions:
```
    OperationError =
       (OperationError){
          Code = "2064"
          Details = ""
          ErrorCode = "RestrictedColumnCombinations"
          Message = "Restricted column combinations selected."
       }
  }
```

After testing, we believe that the following fields should be added to the `Impression Share Performance Statistics` column since they seem to conflict with `BidMatchType`
- TopImpressionRatePercent
- TopImpressionShareLostToBudgetPercent
- TopImpressionShareLostToRankPercent
- TopImpressionSharePercent

# Manual QA steps
 - Verified on clone connection and on our own account that including the including any/all of the above fields with `BidMatchType` causes the `RestrictedColumnCombinations` error to be thrown, and deselecting them resolves the issue
 
# Risks
 - None
 
# Rollback steps
 - revert this branch
