### PR TITLE
Goal and GoalType are now added to the 'AdGroupPerformanceReport'

### DIFF
--- a/tap_bing_ads/exclusions.py
+++ b/tap_bing_ads/exclusions.py
@@ -25,7 +25,9 @@ EXCLUSIONS = {
         'Attributes': [
             'BidMatchType',
             'DeviceOS',
-            'TopVsOther'
+            'TopVsOther',
+            'Goal',
+            'GoalType'
         ],
         'ImpressionSharePerformanceStatistics': [
             'AbsoluteTopImpressionSharePercent',


### PR DESCRIPTION
# Description of change

Added `Goal` and `GoalType` as exclusion in the `AdGroupPerformanceReport` table. Bing-ads API throws a `RestrictedColumnCombinations` error if you attempt to query for it with the other `ImpressionSharePerformanceStatistics`

# Manual QA steps
 - Ran a lot of sync jobs with different fields selected to test out the exclusions.
 
# Risks
 - If a customer has already selected fields that throw this error, the next time they run discovery they will be blocked from deselecting the fields because they are disabled.
 - Other streams may also need to have Goal and GoalType added to the exclusion list.
 
# Rollback steps
 - revert this branch
