### PR TITLE
Add Required Field for GoalsAndFunnels Report

### DIFF
--- a/tap_bing_ads/reports.py
+++ b/tap_bing_ads/reports.py
@@ -31,7 +31,8 @@ REPORT_SPECIFIC_REQUIRED_FIELDS = {
         'Clicks',
         'Ctr',
         'Impressions'
-    ]
+    ],
+    'GoalsAndFunnelsReport': ['Goal']
 }
 
 ## Any not listed here are strings


### PR DESCRIPTION
# Description of change
- Adds report-specific required field `Goal` to `GoalsAndFunnelsReport` in reports.py based on requirements listed here: https://docs.microsoft.com/en-us/advertising/reporting-service/goalsandfunnelsreportcolumn?view=bingads-13#requiredcolumns

# Manual QA steps
 - left for reviewers
 
# Risks
 - low. makes a field automatically included that is not currently automatically included.
 
# Rollback steps
 - revert this branch
