### PR TITLE
Update exclusions to match the second set of pairs in docs

### DIFF
--- a/tap_bing_ads/__init__.py
+++ b/tap_bing_ads/__init__.py
@@ -391,10 +391,17 @@ def metadata_fn(report_name, field, required_fields):
         mdata = {"metadata": {"inclusion": "available"}, "breadcrumb": ["properties", field]}
 
     if EXCLUSIONS.get(report_name):
-        if field in EXCLUSIONS[report_name]['Attributes']:
-            mdata['metadata']['fieldExclusions'] = [['properties', p] for p in EXCLUSIONS[report_name]['ImpressionSharePerformanceStatistics']]
-        if field in EXCLUSIONS[report_name]['ImpressionSharePerformanceStatistics']:
-            mdata['metadata']['fieldExclusions'] = [['properties', p] for p in EXCLUSIONS[report_name]['Attributes']]
+        for group_set in EXCLUSIONS[report_name]:
+            if field in group_set['Attributes']:
+                mdata['metadata']['fieldExclusions'] = [
+                    *mdata['metadata'].get('fieldExclusions', []),
+                    *[['properties', p] for p in group_set['ImpressionSharePerformanceStatistics']]
+                ]
+            if field in group_set['ImpressionSharePerformanceStatistics']:
+                mdata['metadata']['fieldExclusions'] = [
+                    *mdata['metadata'].get('fieldExclusions', []),
+                    *[['properties', p] for p in group_set['Attributes']]
+                ]
 
     return mdata
 

--- a/tap_bing_ads/exclusions.py
+++ b/tap_bing_ads/exclusions.py
@@ -1,76 +1,138 @@
+"""
+Defines the field exclusion rules for Bing Ads/Microsoft Ads reports.
+The structure is for each report, there are groups of fields that cannot
+be selected with the associated group.
+
+Docs: https://docs.microsoft.com/en-us/advertising/guides/reports?view=bingads-13#columnrestrictions
+
+"""
+
 EXCLUSIONS = {
-    'AccountPerformanceReport': {
-        'Attributes': [
-            'BidMatchType',
-            'DeviceOS',
-            'TopVsOther'
-        ],
-        'ImpressionSharePerformanceStatistics': [
-            'AbsoluteTopImpressionSharePercent',
-            'ClickSharePercent',
-            'ExactMatchImpressionSharePercent',
-            'ImpressionLostToAdRelevancePercent',
-            'ImpressionLostToBidPercent',
-            'ImpressionLostToBudgetPercent',
-            'ImpressionLostToExpectedCtrPercent',
-            'ImpressionLostToRankPercent',
-            'ImpressionSharePercent',
-            'TopImpressionRatePercent',
-            'TopImpressionShareLostToBudgetPercent',
-            'TopImpressionShareLostToRankPercent',
-            'TopImpressionSharePercent'
-        ]
-    },
-    'AdGroupPerformanceReport': {
-        'Attributes': [
-            'BidMatchType',
-            'DeviceOS',
-            'TopVsOther',
-            'Goal',
-            'GoalType'
-        ],
-        'ImpressionSharePerformanceStatistics': [
-            'AbsoluteTopImpressionSharePercent',
-            'ClickSharePercent',
-            'ExactMatchImpressionSharePercent',
-            'ImpressionLostToAdRelevancePercent',
-            'ImpressionLostToBidPercent',
-            'ImpressionLostToBudgetPercent',
-            'ImpressionLostToExpectedCtrPercent',
-            'ImpressionLostToRankPercent',
-            'ImpressionSharePercent',
-            'TopImpressionRatePercent',
-            'TopImpressionShareLostToBudgetPercent',
-            'TopImpressionShareLostToRankPercent',
-            'TopImpressionSharePercent'
-        ]
-    },
-    'CampaignPerformanceReport': {
-        'Attributes': [
-            'BidMatchType',
-            'DeviceOS',
-            'TopVsOther',
-            'BudgetAssociationStatus',
-            'BudgetName',
-            'BudgetStatus'
-        ],
-        'ImpressionSharePerformanceStatistics': [
-            'AbsoluteTopImpressionSharePercent',
-            'ClickSharePercent',
-            'ExactMatchImpressionSharePercent',
-            'ImpressionLostToAdRelevancePercent',
-            'ImpressionLostToBidPercent',
-            'ImpressionLostToBudgetPercent',
-            'ImpressionLostToExpectedCtrPercent',
-            'ImpressionLostToRankPercent',
-            'ImpressionSharePercent',
-            'TopImpressionRatePercent',
-            'TopImpressionShareLostToBudgetPercent',
-            'TopImpressionShareLostToRankPercent',
-            'TopImpressionSharePercent'
-        ]
-    },
-    'ProductDimensionPerformanceReport': {
+    'AccountPerformanceReport': [
+        {
+            'Attributes': [
+                'CustomerId',
+                'CustomerName',
+                'DeliveredMatchType'
+            ],
+            'ImpressionSharePerformanceStatistics': [
+                'AudienceImpressionLostToBudgetPercent',
+                'AudienceImpressionLostToRankPercent',
+                'AudienceImpressionSharePercent'
+            ]
+        },
+        {
+            'Attributes': [
+                'BidMatchType',
+                'DeviceOS',
+                'Goal',
+                'GoalType',
+                'TopVsOther'
+            ],
+            'ImpressionSharePerformanceStatistics': [
+                'AudienceImpressionLostToBudgetPercent',
+                'AudienceImpressionLostToRankPercent',
+                'AudienceImpressionSharePercent',
+                'AbsoluteTopImpressionSharePercent',
+                'ClickSharePercent',
+                'ExactMatchImpressionSharePercent',
+                'ImpressionLostToAdRelevancePercent',
+                'ImpressionLostToBidPercent',
+                'ImpressionLostToBudgetPercent',
+                'ImpressionLostToExpectedCtrPercent',
+                'ImpressionLostToRankPercent',
+                'ImpressionLostToRankAggPercent',
+                'ImpressionSharePercent',
+                'TopImpressionRatePercent',
+                'TopImpressionShareLostToBudgetPercent',
+                'TopImpressionShareLostToRankPercent',
+                'TopImpressionSharePercent'
+            ]
+        }],
+    'AdGroupPerformanceReport': [
+        {
+            'Attributes': [
+                'CustomerId',
+                'CustomerName',
+                'DeliveredMatchType'
+            ],
+            'ImpressionSharePerformanceStatistics': [
+                'AudienceImpressionLostToBudgetPercent',
+                'AudienceImpressionLostToRankPercent',
+                'AudienceImpressionSharePercent'
+            ]
+        },{
+            'Attributes': [
+                'BidMatchType',
+                'DeviceOS',
+                'TopVsOther',
+                'Goal',
+                'GoalType'
+            ],
+            'ImpressionSharePerformanceStatistics': [
+                'AbsoluteTopImpressionSharePercent',
+                'AudienceImpressionLostToBudgetPercent',
+                'AudienceImpressionLostToRankPercent',
+                'AudienceImpressionSharePercent',
+                'ClickSharePercent',
+                'ExactMatchImpressionSharePercent',
+                'ImpressionLostToAdRelevancePercent',
+                'ImpressionLostToBidPercent',
+                'ImpressionLostToBudgetPercent',
+                'ImpressionLostToExpectedCtrPercent',
+                'ImpressionLostToRankPercent',
+                'ImpressionLostToRankAggPercent',
+                'ImpressionSharePercent',
+                'TopImpressionRatePercent',
+                'TopImpressionShareLostToBudgetPercent',
+                'TopImpressionShareLostToRankPercent',
+                'TopImpressionSharePercent'
+            ]
+        }],
+    'CampaignPerformanceReport': [
+        {
+            'Attributes': [
+                'CustomerId',
+                'CustomerName',
+                'DeliveredMatchType'
+            ],
+            'ImpressionSharePerformanceStatistics': [
+                'AudienceImpressionLostToBudgetPercent',
+                'AudienceImpressionLostToRankPercent',
+                'AudienceImpressionSharePercent'
+            ]
+        },{
+            'Attributes': [
+                'BidMatchType',
+                'DeviceOS',
+                'Goal',
+                'GoalType',
+                'TopVsOther',
+                'BudgetAssociationStatus',
+                'BudgetName',
+                'BudgetStatus'
+            ],
+            'ImpressionSharePerformanceStatistics': [
+                'AudienceImpressionLostToBudgetPercent',
+                'AudienceImpressionLostToRankPercent',
+                'AudienceImpressionSharePercent',
+                'AbsoluteTopImpressionSharePercent',
+                'ClickSharePercent',
+                'ExactMatchImpressionSharePercent',
+                'ImpressionLostToAdRelevancePercent',
+                'ImpressionLostToBidPercent',
+                'ImpressionLostToBudgetPercent',
+                'ImpressionLostToExpectedCtrPercent',
+                'ImpressionLostToRankPercent',
+                'ImpressionLostToRankAggPercent',
+                'ImpressionSharePercent',
+                'TopImpressionRatePercent',
+                'TopImpressionShareLostToBudgetPercent',
+                'TopImpressionShareLostToRankPercent',
+                'TopImpressionSharePercent'
+            ]
+        }],
+    'ProductDimensionPerformanceReport': [{
         'Attributes': [
             'AdDistribution',
             'AdId',
@@ -90,8 +152,8 @@ EXCLUSIONS = {
             'ImpressionLostToRankPercent',
             'ImpressionSharePercent'
         ]
-    },
-    'ProductPartitionPerformanceReport': {
+    }],
+    'ProductPartitionPerformanceReport': [{
         'Attributes': [
             'AdDistribution',
             'AdId',
@@ -113,5 +175,5 @@ EXCLUSIONS = {
             'ImpressionLostToRankPercent',
             'ImpressionSharePercent'
         ]
-    }
+    }]
 }


### PR DESCRIPTION
# Description of change
The documentation on reports and the fields that can be selected with other fields is rather misleading. There is a table with two groups of fields that are mutually exclusive, but above that, there is another set of groups in a purple comment that are ALSO (differently) mutually exclusive.

Documentation can be found here: https://docs.microsoft.com/en-us/advertising/guides/reports?view=bingads-13#columnrestrictions

# Manual QA steps
 - I confirmed that the parenthetical groups were mutually exclusive regardless of the table
 - Ran a report to confirm that for `ad_group_performance` and `campaign_performance`
 
# Risks
 - Low, this is not matching Microsoft's pattern as it is, and most exclusion reports/fields documented are not even offered in the tap.
 
# Rollback steps
 - revert this branch and release new minor version
