### PR TITLE
update bingads package to 13.0.4.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     py_modules=['tap_bingads'],
     install_requires=[
         'arrow==0.12.0',
-        'bingads==12.13.1',
+        'bingads==13.0.4.1',
         'requests==2.20.0',
         'singer-python==5.9.0',
         'stringcase==1.2.0',


### PR DESCRIPTION
# Description of change
The tap is using an old bingads package. When I call it with my account, I get the following error:

![image](https://user-images.githubusercontent.com/46843047/90224135-7eb6b400-de0f-11ea-8b4b-f676cb2ffef7.png)

After doing an upgrade to the current bingads package version 13.0.4.1, it works:

![image](https://user-images.githubusercontent.com/46843047/90224060-66469980-de0f-11ea-8dd3-6ccd78e78d6d.png)


# Rollback steps
 - revert this branch
