### PR TITLE
Bump bingads version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     py_modules=['tap_bingads'],
     install_requires=[
         'arrow==0.12.0',
-        'bingads==13.0.4.1',
+        'bingads==13.0.3',
         'requests==2.20.0',
         'singer-python==5.9.0',
         'stringcase==1.2.0',

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     py_modules=['tap_bingads'],
     install_requires=[
         'arrow==0.12.0',
-        'bingads==12.13.1',
+        'bingads==12.13.2',
         'requests==2.20.0',
         'singer-python==5.9.0',
         'stringcase==1.2.0',

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     py_modules=['tap_bingads'],
     install_requires=[
         'arrow==0.12.0',
-        'bingads==13.0.5',
+        'bingads==13.0.4.1',
         'requests==2.20.0',
         'singer-python==5.9.0',
         'stringcase==1.2.0',

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     py_modules=['tap_bingads'],
     install_requires=[
         'arrow==0.12.0',
-        'bingads==12.13.2',
+        'bingads==13.0.5',
         'requests==2.20.0',
         'singer-python==5.9.0',
         'stringcase==1.2.0',

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     py_modules=['tap_bingads'],
     install_requires=[
         'arrow==0.12.0',
-        'bingads==12.13.6',
+        'bingads==12.13.1',
         'requests==2.20.0',
         'singer-python==5.9.0',
         'stringcase==1.2.0',

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     py_modules=['tap_bingads'],
     install_requires=[
         'arrow==0.12.0',
-        'bingads==12.13.2',
+        'bingads==12.13.1',
         'requests==2.20.0',
         'singer-python==5.9.0',
         'stringcase==1.2.0',

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     py_modules=['tap_bingads'],
     install_requires=[
         'arrow==0.12.0',
-        'bingads==12.13.1',
+        'bingads==13.0.4.1',
         'requests==2.20.0',
         'singer-python==5.9.0',
         'stringcase==1.2.0',

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     py_modules=['tap_bingads'],
     install_requires=[
         'arrow==0.12.0',
-        'bingads==13.0.4.1',
+        'bingads==12.13.1',
         'requests==2.20.0',
         'singer-python==5.9.0',
         'stringcase==1.2.0',

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     py_modules=['tap_bingads'],
     install_requires=[
         'arrow==0.12.0',
-        'bingads==12.13.1',
+        'bingads==12.13.6',
         'requests==2.20.0',
         'singer-python==5.9.0',
         'stringcase==1.2.0',

--- a/tap_bing_ads/__init__.py
+++ b/tap_bing_ads/__init__.py
@@ -107,7 +107,8 @@ def create_sdk_client(service, account_id):
     authentication = OAuthWebAuthCodeGrant(
         CONFIG['oauth_client_id'],
         CONFIG['oauth_client_secret'],
-        '') ## redirect URL not needed for refresh token
+        '',
+        require_live_connect=True) ## redirect URL not needed for refresh token
 
     authentication.request_oauth_tokens_by_refresh_token(CONFIG['refresh_token'])
 

--- a/tap_bing_ads/__init__.py
+++ b/tap_bing_ads/__init__.py
@@ -108,7 +108,7 @@ def create_sdk_client(service, account_id):
         CONFIG['oauth_client_id'],
         CONFIG['oauth_client_secret'],
         '',
-        require_live_connect=True) ## redirect URL not needed for refresh token
+        require_live_connect=CONFIG.get('require_live_connect', True)) ## redirect URL not needed for refresh token
 
     authentication.request_oauth_tokens_by_refresh_token(CONFIG['refresh_token'])
 

--- a/tap_bing_ads/__init__.py
+++ b/tap_bing_ads/__init__.py
@@ -104,11 +104,13 @@ def create_sdk_client(service, account_id):
     LOGGER.info('Creating SOAP client with OAuth refresh credentials for service: %s, account_id %s',
                 service, account_id)
 
+    require_live_connect = CONFIG.get('require_live_connect', 'True') == 'True'
+
     authentication = OAuthWebAuthCodeGrant(
         CONFIG['oauth_client_id'],
         CONFIG['oauth_client_secret'],
         '',
-        require_live_connect=CONFIG.get('require_live_connect', True)) ## redirect URL not needed for refresh token
+        require_live_connect=require_live_connect) ## redirect URL not needed for refresh token
 
     authentication.request_oauth_tokens_by_refresh_token(CONFIG['refresh_token'])
 


### PR DESCRIPTION
# Description of change
Bump bingads version and created an optional config parameter `require_live_connect`, which defaults to True. If it is "False".

Did not push the `bingads` version all the way to `13.0.5` because `13.0.4` and beyond cause errors with the scope inside of the `bingads` package version.

Reported the issue with scopes:
https://github.com/BingAds/BingAds-Python-SDK/issues/164

# Manual QA steps
 - Created a connection locally and it was able to successfully query the bingads api.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
