### PR TITLE
Update exclusions.py

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
           name: 'JSON Validator'
           command: |
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            stitch-validate-json /usr/local/share/virtualenvs/tap-bing-ads/lib/python3.5/site-packages/tap_bing-ads/schemas/*.json
+            stitch-validate-json /usr/local/share/virtualenvs/tap-bing-ads/lib/python3.5/site-packages/tap_bing_ads/schemas/*.json
       - add_ssh_keys
       - run:
           name: 'Integration Tests'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,11 +15,6 @@ jobs:
             source /usr/local/share/virtualenvs/tap-bing-ads/bin/activate
             pip install -U 'pip<19.2' setuptools
             pip install .[dev]
-      - run:
-          name: 'JSON Validator'
-          command: |
-            source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            stitch-validate-json /usr/local/share/virtualenvs/tap-bing-ads/lib/python3.5/site-packages/tap_bing_ads/schemas/*.json
       - add_ssh_keys
       - run:
           name: 'Integration Tests'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,11 @@ jobs:
             source /usr/local/share/virtualenvs/tap-bing-ads/bin/activate
             pip install -U 'pip<19.2' setuptools
             pip install .[dev]
+      - run:
+          name: 'JSON Validator'
+          command: |
+            source /usr/local/share/virtualenvs/tap-tester/bin/activate
+            stitch-validate-json /usr/local/share/virtualenvs/tap-bing-ads/lib/python3.5/site-packages/tap_bing-ads/schemas/*.json
       - add_ssh_keys
       - run:
           name: 'Integration Tests'

--- a/tap_bing_ads/exclusions.py
+++ b/tap_bing_ads/exclusions.py
@@ -18,7 +18,8 @@ EXCLUSIONS = {
             'ImpressionSharePerformanceStatistics': [
                 'AudienceImpressionLostToBudgetPercent',
                 'AudienceImpressionLostToRankPercent',
-                'AudienceImpressionSharePercent'
+                'AudienceImpressionSharePercent',
+                'RelativeCtr'
             ]
         },
         {
@@ -30,22 +31,23 @@ EXCLUSIONS = {
                 'TopVsOther'
             ],
             'ImpressionSharePerformanceStatistics': [
-                'AudienceImpressionLostToBudgetPercent',
-                'AudienceImpressionLostToRankPercent',
-                'AudienceImpressionSharePercent',
-                'AbsoluteTopImpressionSharePercent',
                 'AbsoluteTopImpressionRatePercent',
                 'AbsoluteTopImpressionShareLostToBudgetPercent',
                 'AbsoluteTopImpressionShareLostToRankPercent',
+                'AbsoluteTopImpressionSharePercent',
+                'AudienceImpressionLostToBudgetPercent',
+                'AudienceImpressionLostToRankPercent',
+                'AudienceImpressionSharePercent',
                 'ClickSharePercent',
                 'ExactMatchImpressionSharePercent',
                 'ImpressionLostToAdRelevancePercent',
                 'ImpressionLostToBidPercent',
                 'ImpressionLostToBudgetPercent',
                 'ImpressionLostToExpectedCtrPercent',
-                'ImpressionLostToRankPercent',
                 'ImpressionLostToRankAggPercent',
+                'ImpressionLostToRankPercent',
                 'ImpressionSharePercent',
+                'RelativeCtr',
                 'TopImpressionRatePercent',
                 'TopImpressionShareLostToBudgetPercent',
                 'TopImpressionShareLostToRankPercent',
@@ -62,21 +64,22 @@ EXCLUSIONS = {
             'ImpressionSharePerformanceStatistics': [
                 'AudienceImpressionLostToBudgetPercent',
                 'AudienceImpressionLostToRankPercent',
-                'AudienceImpressionSharePercent'
+                'AudienceImpressionSharePercent',
+                'RelativeCtr'
             ]
         },{
             'Attributes': [
                 'BidMatchType',
                 'DeviceOS',
-                'TopVsOther',
                 'Goal',
-                'GoalType'
+                'GoalType',
+                'TopVsOther'
             ],
             'ImpressionSharePerformanceStatistics': [
-                'AbsoluteTopImpressionSharePercent',
                 'AbsoluteTopImpressionRatePercent',
                 'AbsoluteTopImpressionShareLostToBudgetPercent',
                 'AbsoluteTopImpressionShareLostToRankPercent',
+                'AbsoluteTopImpressionSharePercent',
                 'AudienceImpressionLostToBudgetPercent',
                 'AudienceImpressionLostToRankPercent',
                 'AudienceImpressionSharePercent',
@@ -86,9 +89,10 @@ EXCLUSIONS = {
                 'ImpressionLostToBidPercent',
                 'ImpressionLostToBudgetPercent',
                 'ImpressionLostToExpectedCtrPercent',
-                'ImpressionLostToRankPercent',
                 'ImpressionLostToRankAggPercent',
+                'ImpressionLostToRankPercent',
                 'ImpressionSharePercent',
+                'RelativeCtr',
                 'TopImpressionRatePercent',
                 'TopImpressionShareLostToBudgetPercent',
                 'TopImpressionShareLostToRankPercent',
@@ -105,32 +109,36 @@ EXCLUSIONS = {
             'ImpressionSharePerformanceStatistics': [
                 'AudienceImpressionLostToBudgetPercent',
                 'AudienceImpressionLostToRankPercent',
-                'AudienceImpressionSharePercent'
+                'AudienceImpressionSharePercent',
+                'RelativeCtr'
             ]
         },{
             'Attributes': [
                 'BidMatchType',
+                'BudgetAssociationStatus',
+                'BudgetName',
+                'BudgetStatus',
                 'DeviceOS',
                 'Goal',
                 'GoalType',
-                'TopVsOther',
-                'BudgetAssociationStatus',
-                'BudgetName',
-                'BudgetStatus'
+                'TopVsOther'
             ],
             'ImpressionSharePerformanceStatistics': [
+                'AbsoluteTopImpressionRatePercent',
+                'AbsoluteTopImpressionShareLostToBudgetPercent',
+                'AbsoluteTopImpressionShareLostToRankPercent',
+                'AbsoluteTopImpressionSharePercent',
                 'AudienceImpressionLostToBudgetPercent',
                 'AudienceImpressionLostToRankPercent',
                 'AudienceImpressionSharePercent',
-                'AbsoluteTopImpressionSharePercent',
                 'ClickSharePercent',
                 'ExactMatchImpressionSharePercent',
                 'ImpressionLostToAdRelevancePercent',
                 'ImpressionLostToBidPercent',
                 'ImpressionLostToBudgetPercent',
                 'ImpressionLostToExpectedCtrPercent',
-                'ImpressionLostToRankPercent',
                 'ImpressionLostToRankAggPercent',
+                'ImpressionLostToRankPercent',
                 'ImpressionSharePercent',
                 'TopImpressionRatePercent',
                 'TopImpressionShareLostToBudgetPercent',
@@ -144,6 +152,9 @@ EXCLUSIONS = {
             'AdId',
             'AdStatus',
             'ClickType',
+            'ClickTypeId',
+            'Goal',
+            'GoalType',
             'Language',
             'LocalStoreCode',
             'Network',
@@ -151,12 +162,19 @@ EXCLUSIONS = {
         ],
         'ImpressionSharePerformanceStatistics': [
             'AbsoluteTopImpressionSharePercent',
+            'AbsoluteTopImpressionShareLostToBudgetPercent',
+            'AbsoluteTopImpressionShareLostToRankPercent',
+            'AbsoluteTopImpressionSharePercent',
             'BenchmarkBid',
             'BenchmarkCtr',
             'ClickSharePercent',
             'ImpressionLostToBudgetPercent',
             'ImpressionLostToRankPercent',
-            'ImpressionSharePercent'
+            'ImpressionSharePercent',
+            'TopImpressionRatePercent',
+            'TopImpressionShareLostToBudgetPercent',
+            'TopImpressionShareLostToRankPercent',
+            'TopImpressionSharePercent'
         ]
     }],
     'ProductPartitionPerformanceReport': [{
@@ -166,7 +184,10 @@ EXCLUSIONS = {
             'AdStatus',
             'BidMatchType',
             'ClickType',
+            'ClickTypeId',
             'DeliveredMatchType',
+            'Goal',
+            'GoalType',
             'Language',
             'LocalStoreCode',
             'Network',


### PR DESCRIPTION
# Description of change
Adds several new fields to Attributes and ImpressionSharePerformanceStatistics for most reports.

Alphabetizes Attributes and ImpressionSharePerformanceStatistics objects in each report for easier updates / cross reference against Microsoft Documentation in the future.

# Manual QA steps
Tested with local clone of client connection.
 
# Risks
Users in violation of these new field exclusions (who would already be encountering exclusion violation errors) will need to use the `Deselect All Conflicting Fields` button to adhere to exclusion rules.
 
# Rollback steps
 - revert this branch
