### PR TITLE
Add table-key-properties to key_property

### DIFF
--- a/tap_bing_ads/__init__.py
+++ b/tap_bing_ads/__init__.py
@@ -763,7 +763,8 @@ async def sync_report_interval(client, account_id, report_stream,
     report_name = stringcase.pascalcase(report_stream.stream)
 
     report_schema = get_report_schema(client, report_name)
-    singer.write_schema(report_stream.stream, report_schema, [])
+    singer.write_schema(report_stream.stream, report_schema,
+                        metadata.get(metadata.to_map(report_stream.metadata), (), 'table-key-properties') or [])
 
     report_time = arrow.get().isoformat()
 


### PR DESCRIPTION
# Description of change
Allow `table-key-properties` to be added to the metadata and put into `key_property` in the SCHEMA, this way a target will be able to read the primary keys.

# Manual QA steps
 - Run the tap and look at the final SCHEMA.
 
# Risks
 - None, if `table-key-properties` is not defined, it will default to `[]`.
 
# Rollback steps
 - Revert this branch.
