### PR TITLE
Remove null characters from the CSV

### DIFF
--- a/tap_bing_ads/__init__.py
+++ b/tap_bing_ads/__init__.py
@@ -695,7 +695,7 @@ def stream_report(stream_name, report_name, url, report_time):
                 header_line = next(csv_file)[1:-1]
                 headers = header_line.replace('"', '').split(',')
 
-                reader = csv.DictReader(csv_file, fieldnames=headers)
+                reader = csv.DictReader((line.replace('\0', '') for line in csv_file), fieldnames=headers)
 
                 with metrics.record_counter(stream_name) as counter:
                     for row in reader:


### PR DESCRIPTION
# Description of change
Remove null characters from the CSV.

# Manual QA steps
 - Ran on a connection which was failing due to null characters coming through the CSV file streamed from Bing ads. Running on master the sync failed, running on this branch the sync succeeded.
 
# Risks
 - This is a pattern we have used for CSV readers in other taps and any Bing ads reports this would affect would be failing without this change.
 
# Rollback steps
 - revert this branch
