### PR TITLE
Add retry logic for failures in discovery and sync

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -220,7 +220,7 @@ class BingAdsBaseTest(unittest.TestCase):
         # Assert that the check job succeeded
         exit_status = menagerie.get_exit_status(conn_id, check_job_name)
         try:
-            menagerie.verify_sync_exit_status(self, exit_status, sync_job_name)
+            menagerie.verify_sync_exit_status(self, exit_status, check_job_name)
         except AssertionError as e:
             if exit_status['discovery_error_message']:
                 print("*******************RETRYING CHECK FOR DISCOVERY FAILURE*******************")

--- a/tests/base.py
+++ b/tests/base.py
@@ -254,8 +254,9 @@ class BingAdsBaseTest(unittest.TestCase):
         try:
             menagerie.verify_sync_exit_status(self, exit_status, sync_job_name)
         except AssertionError as e:
-            if "tap_exit_status for job" in e.message:
-                raise RetryableTapError(e.message)
+            if exit_status['discovery_error_message'] or exit_status['tap_error_message']:
+                print("*******************RETRYING SYNC FOR TAP/DISCOVERY FAILURE*******************"
+                raise RetryableTapError(e)
 
             raise
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -255,7 +255,7 @@ class BingAdsBaseTest(unittest.TestCase):
             menagerie.verify_sync_exit_status(self, exit_status, sync_job_name)
         except AssertionError as e:
             if exit_status['discovery_error_message'] or exit_status['tap_error_message']:
-                print("*******************RETRYING SYNC FOR TAP/DISCOVERY FAILURE*******************"
+                print("*******************RETRYING SYNC FOR TAP/DISCOVERY FAILURE*******************")
                 raise RetryableTapError(e)
 
             raise

--- a/tests/base.py
+++ b/tests/base.py
@@ -220,7 +220,7 @@ class BingAdsBaseTest(unittest.TestCase):
         # Assert that the check job succeeded
         exit_status = menagerie.get_exit_status(conn_id, check_job_name)
         try:
-            menagerie.verify_sync_exit_status(self, exit_status, check_job_name)
+            menagerie.verify_check_exit_status(self, exit_status, check_job_name)
         except AssertionError as e:
             if exit_status['discovery_error_message']:
                 print("*******************RETRYING CHECK FOR DISCOVERY FAILURE*******************")

--- a/tests/base.py
+++ b/tests/base.py
@@ -240,12 +240,15 @@ class BingAdsBaseTest(unittest.TestCase):
     @backoff.on_exception(backoff_wait_times,
                           RetryableTapError,
                           max_tries=3)
-    def run_and_verify_sync(self, conn_id):
+    def run_and_verify_sync(self, conn_id, state):
         """
         Run a sync job and make sure it exited properly.
         Return a dictionary with keys of streams synced
         and values of records synced for each stream
         """
+        # reset state to the state at the start of the sync in case we got interrupted
+        menagerie.set_state(conn_id, state)
+
         # Run a sync job using orchestrator
         sync_job_name = runner.run_sync_mode(self, conn_id)
 

--- a/tests/test_automatic_fields.py
+++ b/tests/test_automatic_fields.py
@@ -114,7 +114,8 @@ class MinimumSelectionTest(BingAdsBaseTest):
         # COMMENT EVERYTHING DOWN FROM HERE TO ADDRESS BUG_SRCE-4313
 
         # Run a sync job using orchestrator
-        record_count_by_stream = self.run_and_verify_sync(conn_id)
+        state = menagerie.get_state(conn_id)
+        record_count_by_stream = self.run_and_verify_sync(conn_id, state)
 
         actual_fields_by_stream = runner.examine_target_output_for_fields()
 

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -99,7 +99,8 @@ class TestBingAdsBookmarks(BingAdsBaseTest):
         # )
 
         # Run a sync job using orchestrator
-        first_sync_record_count = self.run_and_verify_sync(conn_id)
+        state = menagerie.get_state(conn_id)
+        first_sync_record_count = self.run_and_verify_sync(conn_id, state)
         first_sync_records = runner.get_records_from_target_output()
         first_sync_bookmarks = menagerie.get_state(conn_id)
 
@@ -111,7 +112,8 @@ class TestBingAdsBookmarks(BingAdsBaseTest):
         menagerie.set_state(conn_id, new_state)
 
         # Run a second sync job using orchestrator
-        second_sync_record_count = self.run_and_verify_sync(conn_id)
+        state = menagerie.get_state(conn_id)
+        second_sync_record_count = self.run_and_verify_sync(conn_id, state)
         second_sync_records = runner.get_records_from_target_output()
         second_sync_bookmarks = menagerie.get_state(conn_id)
 

--- a/tests/test_bookmarks_reports.py
+++ b/tests/test_bookmarks_reports.py
@@ -249,7 +249,8 @@ class TestBingAdsBookmarksReports(BingAdsBaseTest):
                                                    select_all_fields=False, specific_fields=streams_to_fields_with_exclusions)
 
         # Run a sync job using orchestrator
-        first_sync_record_count = self.run_and_verify_sync(conn_id)
+        state = menagerie.get_state(conn_id)
+        first_sync_record_count = self.run_and_verify_sync(conn_id, state)
         first_sync_records = runner.get_records_from_target_output()
         first_sync_bookmarks = menagerie.get_state(conn_id)
 
@@ -261,7 +262,8 @@ class TestBingAdsBookmarksReports(BingAdsBaseTest):
         menagerie.set_state(conn_id, new_state)
 
         # Run a second sync job using orchestrator
-        second_sync_record_count = self.run_and_verify_sync(conn_id)
+        state = menagerie.get_state(conn_id)
+        second_sync_record_count = self.run_and_verify_sync(conn_id, state)
         second_sync_records = runner.get_records_from_target_output()
         second_sync_bookmarks = menagerie.get_state(conn_id)
 

--- a/tests/test_start_date.py
+++ b/tests/test_start_date.py
@@ -83,9 +83,8 @@ class BingAdsStartDateTest(BingAdsBaseTest):
         # instantiate connection
         conn_id_1 = self.create_connection()
 
-        # run check mode
-        found_catalogs = menagerie.get_catalogs(conn_id_1)
-        found_catalogs_1 = set(map(lambda c: c['tap_stream_id'], found_catalogs))
+        # run check mode was run when the connection was created, just get the catalog
+        found_catalogs_1 = menagerie.get_catalogs(conn_id_1)
 
         # ensure our expectations are consistent for streams with exclusions
         self.assertSetEqual(self.expected_streams_with_exclusions(), set(self.get_all_attributes().keys()))
@@ -98,7 +97,6 @@ class BingAdsStartDateTest(BingAdsBaseTest):
         # BUG (https://stitchdata.atlassian.net/browse/SRCE-4304)
         # self.perform_and_verify_and_field_selection(conn_id_1, test_catalogs_1_all_fields, select_all_fields=True)
         self.select_all_streams_and_fields(conn_id_1, test_catalogs_1_all_fields, select_all_fields=True) # BUG_SRCE-4304
-        found_catalogs_1 = found_catalogs
         test_catalogs_1_specific_fields = [catalog for catalog in found_catalogs_1
                                            if catalog.get('tap_stream_id') in self.expected_sync_streams()
                                            and catalog.get('tap_stream_id') in self.expected_streams_with_exclusions()]
@@ -128,8 +126,7 @@ class BingAdsStartDateTest(BingAdsBaseTest):
         conn_id_2 = self.create_connection(original_properties=False)
 
         # run check mode
-        found_catalogs = menagerie.get_catalogs(conn_id_2)
-        found_catalogs_2 = set(map(lambda c: c['tap_stream_id'], found_catalogs))
+        found_catalogs_2 = menagerie.get_catalogs(conn_id_2)
 
         # table and field selection
         test_catalogs_2_all_fields = [catalog for catalog in found_catalogs_2
@@ -138,7 +135,6 @@ class BingAdsStartDateTest(BingAdsBaseTest):
         # BUG (https://stitchdata.atlassian.net/browse/SRCE-4304)
         # self.perform_and_verify_and_field_selection(conn_id_2, test_catalogs_2_all_fields, select_all_fields=True)
         self.select_all_streams_and_fields(conn_id_2, test_catalogs_2_all_fields, select_all_fields=True) # BUG_SRCE-4304
-        found_catalogs_2 = found_catalogs
         test_catalogs_2_specific_fields = [catalog for catalog in found_catalogs_2
                                            if catalog.get('tap_stream_id') in self.expected_sync_streams()
                                            and catalog.get('tap_stream_id') in self.expected_streams_with_exclusions()]

--- a/tests/test_start_date.py
+++ b/tests/test_start_date.py
@@ -104,7 +104,8 @@ class BingAdsStartDateTest(BingAdsBaseTest):
                                                    select_all_fields=False, specific_fields=streams_to_fields_with_exclusions)
 
         # run initial sync
-        record_count_by_stream_1 = self.run_and_verify_sync(conn_id_1)
+        state = menagerie.get_state(conn_id)
+        record_count_by_stream_1 = self.run_and_verify_sync(conn_id, state)
 
         replicated_row_count_1 = sum(record_count_by_stream_1.values())
         self.assertGreater(replicated_row_count_1, 0, msg="failed to replicate any data: {}".format(record_count_by_stream_1))
@@ -142,7 +143,8 @@ class BingAdsStartDateTest(BingAdsBaseTest):
                                                    select_all_fields=False, specific_fields=streams_to_fields_with_exclusions)
 
         # run sync
-        record_count_by_stream_2 = self.run_and_verify_sync(conn_id_2)
+        state = menagerie.get_state(conn_id)
+        record_count_by_stream_2 = self.run_and_verify_sync(conn_id, state)
 
         replicated_row_count_2 = sum(record_count_by_stream_2.values())
         self.assertGreater(replicated_row_count_2, 0, msg="failed to replicate any data")

--- a/tests/test_start_date.py
+++ b/tests/test_start_date.py
@@ -104,8 +104,8 @@ class BingAdsStartDateTest(BingAdsBaseTest):
                                                    select_all_fields=False, specific_fields=streams_to_fields_with_exclusions)
 
         # run initial sync
-        state = menagerie.get_state(conn_id)
-        record_count_by_stream_1 = self.run_and_verify_sync(conn_id, state)
+        state = menagerie.get_state(conn_id_1)
+        record_count_by_stream_1 = self.run_and_verify_sync(conn_id_1, state)
 
         replicated_row_count_1 = sum(record_count_by_stream_1.values())
         self.assertGreater(replicated_row_count_1, 0, msg="failed to replicate any data: {}".format(record_count_by_stream_1))
@@ -143,8 +143,8 @@ class BingAdsStartDateTest(BingAdsBaseTest):
                                                    select_all_fields=False, specific_fields=streams_to_fields_with_exclusions)
 
         # run sync
-        state = menagerie.get_state(conn_id)
-        record_count_by_stream_2 = self.run_and_verify_sync(conn_id, state)
+        state = menagerie.get_state(conn_id_2)
+        record_count_by_stream_2 = self.run_and_verify_sync(conn_id_2, state)
 
         replicated_row_count_2 = sum(record_count_by_stream_2.values())
         self.assertGreater(replicated_row_count_2, 0, msg="failed to replicate any data")

--- a/tests/test_start_date.py
+++ b/tests/test_start_date.py
@@ -84,7 +84,8 @@ class BingAdsStartDateTest(BingAdsBaseTest):
         conn_id_1 = self.create_connection()
 
         # run check mode
-        found_catalogs_1 = self.run_and_verify_check_mode(conn_id_1)
+        found_catalogs = menagerie.get_catalogs(conn_id_1)
+        found_catalogs_1 = set(map(lambda c: c['tap_stream_id'], found_catalogs))
 
         # ensure our expectations are consistent for streams with exclusions
         self.assertSetEqual(self.expected_streams_with_exclusions(), set(self.get_all_attributes().keys()))
@@ -97,7 +98,7 @@ class BingAdsStartDateTest(BingAdsBaseTest):
         # BUG (https://stitchdata.atlassian.net/browse/SRCE-4304)
         # self.perform_and_verify_and_field_selection(conn_id_1, test_catalogs_1_all_fields, select_all_fields=True)
         self.select_all_streams_and_fields(conn_id_1, test_catalogs_1_all_fields, select_all_fields=True) # BUG_SRCE-4304
-        found_catalogs_1 = menagerie.get_catalogs(conn_id_1)
+        found_catalogs_1 = found_catalogs
         test_catalogs_1_specific_fields = [catalog for catalog in found_catalogs_1
                                            if catalog.get('tap_stream_id') in self.expected_sync_streams()
                                            and catalog.get('tap_stream_id') in self.expected_streams_with_exclusions()]
@@ -127,7 +128,8 @@ class BingAdsStartDateTest(BingAdsBaseTest):
         conn_id_2 = self.create_connection(original_properties=False)
 
         # run check mode
-        found_catalogs_2 = self.run_and_verify_check_mode(conn_id_2)
+        found_catalogs = menagerie.get_catalogs(conn_id_2)
+        found_catalogs_2 = set(map(lambda c: c['tap_stream_id'], found_catalogs))
 
         # table and field selection
         test_catalogs_2_all_fields = [catalog for catalog in found_catalogs_2
@@ -136,7 +138,7 @@ class BingAdsStartDateTest(BingAdsBaseTest):
         # BUG (https://stitchdata.atlassian.net/browse/SRCE-4304)
         # self.perform_and_verify_and_field_selection(conn_id_2, test_catalogs_2_all_fields, select_all_fields=True)
         self.select_all_streams_and_fields(conn_id_2, test_catalogs_2_all_fields, select_all_fields=True) # BUG_SRCE-4304
-        found_catalogs_2 = menagerie.get_catalogs(conn_id_2)
+        found_catalogs_2 = found_catalogs
         test_catalogs_2_specific_fields = [catalog for catalog in found_catalogs_2
                                            if catalog.get('tap_stream_id') in self.expected_sync_streams()
                                            and catalog.get('tap_stream_id') in self.expected_streams_with_exclusions()]

--- a/tests/test_sync_rows.py
+++ b/tests/test_sync_rows.py
@@ -64,7 +64,8 @@ class BingAdsSyncRows(BingAdsBaseTest):
         self.select_all_streams_and_fields(conn_id, our_catalogs, select_all_fields=False)
 
         # Run a sync job using orchestrator
-        record_count_by_stream = self.run_and_verify_sync(conn_id)
+        state = menagerie.get_state(conn_id)
+        record_count_by_stream = self.run_and_verify_sync(conn_id, state)
 
         # Ensure all records have a value for PK(s)
         records = runner.get_records_from_target_output()

--- a/tests/test_sync_rows.py
+++ b/tests/test_sync_rows.py
@@ -64,17 +64,7 @@ class BingAdsSyncRows(BingAdsBaseTest):
         self.select_all_streams_and_fields(conn_id, our_catalogs, select_all_fields=False)
 
         # Run a sync job using orchestrator
-        sync_job_name = runner.run_sync_mode(self, conn_id)
-
-        # Verify tap and target exit codes
-        exit_status = menagerie.get_exit_status(conn_id, sync_job_name)
-        menagerie.verify_sync_exit_status(self, exit_status, sync_job_name)
-
-        # Verify actual rows were synced
-        record_count_by_stream = runner.examine_target_output_file(self, conn_id, self.expected_sync_streams(), self.expected_pks())
-        replicated_row_count =  sum(record_count_by_stream.values())
-        self.assertGreater(replicated_row_count, 0, msg="failed to replicate any data: {}".format(record_count_by_stream))
-        print("total replicated row count: {}".format(replicated_row_count))
+        record_count_by_stream = self.run_and_verify_sync(conn_id)
 
         # Ensure all records have a value for PK(s)
         records = runner.get_records_from_target_output()


### PR DESCRIPTION
# Description of change
We receive 500s from bing ads which cause the tap to fail and therefor the test to fail.  Although this is a bing-ads issue there should be retry logic in the tap to add additional success and an issue has been created for that https://jira.talendforge.org/browse/TDL-7402

For stability purposed of the test we are going to add retry logic in the test (which will cover up this issue).  This PR implements https://jira.talendforge.org/browse/TDL-14720.

We should consider if this should be removed once the tap ticket is completed.

# Manual QA steps
 - Ran tap-bing-ads test suite
 
# Risks
 - Not all issues may be tap related issues which means this test could still have stability issues.
 - This will cover up real tap issues that happen inconsistently
 
# Rollback steps
 - revert this branch
