### PR TITLE
updated tap-tester image to be stitch-tap-tester

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 jobs:
   build:
     docker:
-      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:tap-tester-v4
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester
     steps:
       - checkout
       - run:
@@ -22,13 +22,7 @@ jobs:
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
             source dev_env.sh
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            run-test --tap=tap-bing-ads \
-                     --target=target-stitch \
-                     --orchestrator=stitch-orchestrator \
-                     --email=harrison+sandboxtest@stitchdata.com \
-                     --password=$SANDBOX_PASSWORD \
-                     --client-id=50 \
-                     tests
+            run-test --tap=tap-bing-ads tests
       - slack/notify-on-failure:
           only_for_branches: master
 


### PR DESCRIPTION
# Description of change
https://jira.talendforge.org/browse/TDL-14782
We updated tap-tester image in the configfile to point to stitch-tap-tester, which is the latest tap-tester image
# Manual QA steps
 - the tests running in circleci should give us a good idea about if this worked
 
# Risks
 - low, this is only for tap-tester
 
# Rollback steps
 - revert this branch
