### PR TITLE
TDL 7402 Add retry logic for 500 errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,6 @@
 version: 2.1
 orbs:
   slack: circleci/slack@3.4.2
-
 jobs:
   build:
     docker:
@@ -17,6 +16,17 @@ jobs:
             pip install .[dev]
       - add_ssh_keys
       - run:
+          name: 'Unit Tests'
+          command: |
+            source /usr/local/share/virtualenvs/tap-bing-ads/bin/activate
+            pip install nose coverage
+            nosetests --with-coverage --cover-erase --cover-package=tap_bing_ads --cover-html-dir=htmlcov tests/unittests
+            coverage html
+      - store_test_results:
+          path: test_output/report.xml
+      - store_artifacts:
+          path: htmlcov
+      - run:
           name: 'Integration Tests'
           command: |
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
@@ -25,7 +35,6 @@ jobs:
             run-test --tap=tap-bing-ads tests
       - slack/notify-on-failure:
           only_for_branches: master
-
 workflows:
   version: 2
   commit:

--- a/tap_bing_ads/__init__.py
+++ b/tap_bing_ads/__init__.py
@@ -64,12 +64,11 @@ def should_retry_httperror(exception):
     try:
         if exception.code == 408:
             return True
-
+     
+        # return true if the status code is between 500 to 600
         return 500 <= exception.code < 600
     except AttributeError:
-        #If Exception raised with status code 408, only then perform backoff, otherwise raise error directly.
-        if type(exception) == Exception and exception.args[0][0] != 408:
-            return False
+        # As ConnectionError, socket.timeout, SSLError, Transport does not have `code` property, it throws AttributeError.
         return True
 def bing_ads_error_handling(fnc):
     """
@@ -79,7 +78,7 @@ def bing_ads_error_handling(fnc):
     """
     @backoff.on_exception(backoff.expo,
                           (socket.timeout, ConnectionError,
-                           ssl.SSLError, HTTPError, suds.transport.TransportError, Exception),
+                           ssl.SSLError, HTTPError, suds.transport.TransportError),
                           giveup=lambda e: not should_retry_httperror(e),
                           max_time=60, # 60 seconds
                           factor=2)

--- a/tap_bing_ads/__init__.py
+++ b/tap_bing_ads/__init__.py
@@ -71,7 +71,7 @@ def should_retry_httperror(exception):
             return True
         elif exception.code == 408:
             return True
-        return 500 <= exception.code < 60
+        return 500 <= exception.code < 600
     except AttributeError:
         return False
 

--- a/tap_bing_ads/__init__.py
+++ b/tap_bing_ads/__init__.py
@@ -73,16 +73,15 @@ def should_retry_httperror(exception):
         return True
 def bing_ads_error_handling(fnc):
     """
-        Retry following errors for maximum 5 times,
+        Retry following errors for 60 seconds,
         socket.timeout, ConnectionError, internal server error(500-range), SSLError, HTTPError(408), Transport error.
         Raise the error direclty for all errors except mentioned above errors.
     """
     @backoff.on_exception(backoff.expo,
                           (socket.timeout, ConnectionError,
                            ssl.SSLError, HTTPError, suds.transport.TransportError, Exception),
-                        #   max_tries=5,
                           giveup=lambda e: not should_retry_httperror(e),
-                          max_time=60, # seconds
+                          max_time=60, # 60 seconds
                           factor=2)
     @functools.wraps(fnc)
     def wrapper(*args, **kwargs):
@@ -686,7 +685,7 @@ def type_report_row(row):
 @bing_ads_error_handling
 def generate_poll_report(client, request_id):
     """
-        Retry following errors for maximum 5 times,
+        Retry following errors for 60 seconds,
         socket.timeout, ConnectionError, internal server error(500-range), SSLError, HTTPError(408), Transport error.
         Raise the error direclty for all errors except mentioned above errors.
     """

--- a/tap_bing_ads/__init__.py
+++ b/tap_bing_ads/__init__.py
@@ -67,9 +67,10 @@ def should_retry_httperror(exception):
             return True
         elif type(exception) == URLError:
             return True
-        elif type(exception) == Exception and exception.args[0][0] == 408:
-            return True
-        elif exception.code == 408:
+        elif (type(exception) == Exception and exception.args[0][0] == 408) or exception.code == 408:
+            # A 408 Request Timeout is an HTTP response status code that indicates the server didn't receive a complete
+            # request message within the server's allotted timeout period. A suds SDK catches HTTPError with status code 408 and
+            # raises Exception: (408, 'Request Timeout'). That's why we retrying this error also.
             return True
         return 500 <= exception.code < 600
     except AttributeError:

--- a/tap_bing_ads/__init__.py
+++ b/tap_bing_ads/__init__.py
@@ -61,11 +61,7 @@ ARRAY_TYPE_REGEX = r'ArrayOf([A-Za-z0-9]+)'
 def should_retry_httperror(exception):
     """ Return true if exception is required to retry otherwise return false """
     try:
-        if isinstance(exception, ConnectionError) or isinstance(exception, ssl.SSLError):
-            return True
-        elif isinstance(exception, suds.transport.TransportError) or isinstance(exception, socket.timeout):
-            return True
-        elif type(exception) == URLError:
+        if isinstance(exception, ConnectionError) or isinstance(exception, ssl.SSLError) or isinstance(exception, suds.transport.TransportError) or isinstance(exception, socket.timeout) or type(exception) == URLError:
             return True
         elif (type(exception) == Exception and exception.args[0][0] == 408) or exception.code == 408:
             # A 408 Request Timeout is an HTTP response status code that indicates the server didn't receive a complete
@@ -78,9 +74,9 @@ def should_retry_httperror(exception):
 
 def bing_ads_error_handling(fnc):
     """
-        Retry following errors for 60 seconds,
-        socket.timeout, ConnectionError, internal server error(500-range), SSLError, URLError, HTTPError(408), Transport errors.
-        Raise the error directly for all errors except mentioned above errors.
+        Retry following errors until 60 seconds(7 or 8 times retry perform).
+        socket.timeout, ConnectionError, internal server error(500-range), SSLError, URLError, HTTPError(408), Transport errors, Exception with 408 error code.
+        If after passing 60 seconds the same error comes, then it will be raised. Raise the error directly for all errors except mentioned above errors.
     """
     @backoff.on_exception(backoff.expo,
                           (Exception),

--- a/tap_bing_ads/__init__.py
+++ b/tap_bing_ads/__init__.py
@@ -82,7 +82,7 @@ def bing_ads_error_handling(fnc):
                            ssl.SSLError, HTTPError, suds.transport.TransportError, Exception),
                         #   max_tries=5,
                           giveup=lambda e: not should_retry_httperror(e),
-                          max_time=10, # seconds
+                          max_time=60, # seconds
                           factor=2)
     @functools.wraps(fnc)
     def wrapper(*args, **kwargs):

--- a/tap_bing_ads/__init__.py
+++ b/tap_bing_ads/__init__.py
@@ -79,7 +79,7 @@ def bing_ads_error_handling(fnc):
     """
         Retry following errors for 60 seconds,
         socket.timeout, ConnectionError, internal server error(500-range), SSLError, URLError, HTTPError(408), Transport errors.
-        Raise the error direclty for all errors except mentioned above errors.
+        Raise the error directly for all errors except mentioned above errors.
     """
     @backoff.on_exception(backoff.expo,
                           (Exception),
@@ -690,7 +690,7 @@ def generate_poll_report(client, request_id):
     """
         Retry following errors for 60 seconds,
         socket.timeout, ConnectionError, internal server error(500-range), SSLError, HTTPError(408), Transport error.
-        Raise the error direclty for all errors except mentioned above errors.
+        Raise the error directly for all errors except mentioned above errors.
     """
     return client.PollGenerateReport(request_id)
     
@@ -704,7 +704,7 @@ async def poll_report(client, account_id, report_name, start_date, end_date, req
                 report_name,
                 start_date,
                 end_date))
-            # As in async method backoff does not work directly we created seprate method to handle it.
+            # As in the async method backoff does not work directly we created a separate method to handle it.
             response = generate_poll_report(client, request_id)
             if response.Status == 'Error':
                 LOGGER.warn(

--- a/tap_bing_ads/__init__.py
+++ b/tap_bing_ads/__init__.py
@@ -69,6 +69,11 @@ def should_retry_httperror(exception):
         return True
 
 def bing_ads_error_handling(fnc):
+    """ 
+        Retry following errors for maximum 5 times,
+        socket.timeout, ConnectionError, internal server error(500-range), SSLError, HTTPError(408), Transport error.
+        Raise the error direclty for all errors except mentioned above errors.
+    """
     @backoff.on_exception(backoff.expo,
                           (socket.timeout, ConnectionError,
                            ssl.SSLError, HTTPError, suds.transport.TransportError),

--- a/tests/unittests/test_backoff_error_handling.py
+++ b/tests/unittests/test_backoff_error_handling.py
@@ -162,7 +162,7 @@ class TestConnectionResetError(unittest.TestCase):
             tap_bing_ads.sync_accounts_stream(['i1'], {})
         except HTTPError:
             pass
-        # verify the code backed off and requested for 5 times
+        # verify the code raise error without backoff
         self.assertEqual(mock_get_account.call_count, 1)
         
        
@@ -262,7 +262,7 @@ class TestConnectionResetError(unittest.TestCase):
             tap_bing_ads.sync_campaigns(mock_client, '', [])
         except HTTPError:
             pass
-        # verify the code backed off and requested for 5 times
+        # verify the code raise error without backoff
         self.assertEqual(mock_client.call_count, 1)
         
     def test_ssl_eof_error_sync_campaigns(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -357,7 +357,7 @@ class TestConnectionResetError(unittest.TestCase):
             tap_bing_ads.sync_ad_groups(mock_client, '', ['dummy_campaign_id'], [])
         except HTTPError:
             pass
-        # verify the code backed off and requested for 5 times
+        # verify the code raise error without backoff
         self.assertEqual(mock_client.call_count, 1)
         
     def test_ssl_eof_error_sync_ad_groups(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -453,7 +453,7 @@ class TestConnectionResetError(unittest.TestCase):
             tap_bing_ads.sync_ads(mock_client, ['dummy_stream'], ['dummy_ad_id'])
         except HTTPError:
             pass
-        # verify the code backed off and requested for 5 times
+        # verify the code raise error without backoff
         self.assertEqual(mock_client.call_count, 1) 
         
     def test_ssl_eof_error_sync_ads(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -567,7 +567,7 @@ class TestConnectionResetError(unittest.TestCase):
                                                force_refresh = True)
         except HTTPError:
             pass
-        # verify the code backed off and requested for 5 times
+        # verify the code raise error without backoff
         self.assertEqual(mock_client.call_count, 1)
         
     @mock.patch("tap_bing_ads.build_report_request")   
@@ -666,7 +666,7 @@ class TestConnectionResetError(unittest.TestCase):
             tap_bing_ads.build_report_request(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date')
         except HTTPError:
             pass
-        # verify the code backed off and requested for 5 times
+        # verify the code raise error without backoff
         self.assertEqual(mock_client.call_count, 1)
         
     def test_ssl_eof_error_build_report_request(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -762,7 +762,7 @@ class TestConnectionResetError(unittest.TestCase):
             tap_bing_ads.get_report_schema(mock_client, '')
         except HTTPError:
             pass
-        # verify the code backed off and requested for 5 times
+        # verify the code raise error without backoff
         self.assertEqual(mock_client.call_count, 1)
          
     def test_ssl_eof_error_get_report_schema(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -858,7 +858,7 @@ class TestConnectionResetError(unittest.TestCase):
             tap_bing_ads.get_type_map(mock_client)
         except HTTPError:
             pass
-        # verify the code backed off and requested for 5 times
+        # verify the code raise error without backoff
         self.assertEqual(mock_client.call_count, 1)
         
     def test_ssl_eof_error_get_type_map(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -954,7 +954,7 @@ class TestConnectionResetError(unittest.TestCase):
             await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
         except HTTPError:
             pass
-        # verify the code backed off and requested for 5 times
+        # verify the code raise error without backoff
         self.assertEqual(mock_client.call_count, 1)
         
     async def test_ssl_eof_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -1086,7 +1086,7 @@ class TestConnectionResetError(unittest.TestCase):
             tap_bing_ads.create_sdk_client('dummy_service', {})
         except HTTPError:
             pass
-        # verify the code backed off and requested for 5 times
+        # verify the code raise error without backoff
         self.assertEqual(mock_oauth.call_count, 1)
         
         

--- a/tests/unittests/test_backoff_error_handling.py
+++ b/tests/unittests/test_backoff_error_handling.py
@@ -11,41 +11,36 @@ class MockClient():
     '''Mocked ServiceClient class and it's method to pass the test case'''
     def __init__(self, error):
         self.error = error
-        self.count = 0
 
     def GetCampaignsByAccountId(self, AccountId, CampaignType):
-        self.count = self.count + 1
+        """ Mocked GetCampaignsByAccountId to test the backoff in sync_campaigns method """
         raise self.error
 
     def GetAdGroupsByCampaignId(self, CampaignId):
-        self.count = self.count + 1
+        """ Mocked GetAdGroupsByCampaignId to test the backoff in sync_ad_groups method"""
         raise self.error
 
     def GetAdsByAdGroupId(self, AdGroupId, AdTypes):
-        self.count = self.count + 1
+        """ Mocked GetAdsByAdGroupId test to the backoff in sync_ads method"""
         raise self.error
 
     def SubmitGenerateReport(self, report_request):
-        self.count = self.count + 1
+        """ Mocked SubmitGenerateReport to test the backoff in get_report_request_id method"""
         raise self.error
 
     def PollGenerateReport(self, request_id):
-        self.count = self.count + 1
+        """ Mocked PollGenerateReport to test the backoff in poll_report method"""
         raise self.error
 
     @property
     def factory(self):
-        self.count = self.count + 1
+        """ Mocked factory to test backoff the in build_report_request method"""
         raise self.error
 
     @property
     def soap_client(self):
-        self.count = self.count + 1
+        """ Mocked soap_client to test backoff in get_type_map method"""
         raise self.error
-
-    @property
-    def call_count(self):
-        return self.count
 
 @mock.patch("tap_bing_ads.filter_selected_fields_many", return_value = '')
 @mock.patch("singer.write_records", return_value = '')

--- a/tests/unittests/test_backoff_error_handling.py
+++ b/tests/unittests/test_backoff_error_handling.py
@@ -1924,6 +1924,7 @@ class TestBackoffError(unittest.TestCase):
             tap_bing_ads.create_sdk_client('dummy_service', {})
         except HTTPError:
             pass
+        after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code raise error without backoff
         # time_difference should be less or equal 1 as it directly raise the error without backoff

--- a/tests/unittests/test_backoff_error_handling.py
+++ b/tests/unittests/test_backoff_error_handling.py
@@ -6,7 +6,8 @@ import json
 from urllib.error import HTTPError
 import ssl
 from suds.transport import TransportError
-    
+import datetime
+
 class MockClient():
     '''Mocked ServiceClient class and it's method to pass the test case'''
     def __init__(self, error):
@@ -51,7 +52,6 @@ class MockClient():
     def call_count(self):
         return self.count
 
-@mock.patch("time.sleep")
 @mock.patch("tap_bing_ads.filter_selected_fields_many", return_value = '')
 @mock.patch("singer.write_records", return_value = '')
 @mock.patch("singer.metrics", return_value = '')
@@ -75,17 +75,22 @@ class TestBackoffError(unittest.TestCase):
                                                     mock_write_schema, mock_get_bookmark,
                                                     mock_sobject_to_dict, mock_write_state,
                                                     mock_write_bookmark, mock_metrics, mock_write_records,
-                                                    mock_filter_selected_fields_many,mock_sleep):
+                                                    mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the connection reset error 5 times.
+        Test that tap retry for 60 seconds on the connection reset error.
         '''
         mock_get_account.side_effect = socket.error(104, 'Connection reset by peer')
+        before_time = datetime.datetime.now()
         try:
             tap_bing_ads.sync_accounts_stream(['i1'], {})
         except ConnectionResetError:
             pass
-        # verify the code backed off and requested for 5 times
-        self.assertEqual(mock_get_account.call_count, 5)
+        
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
         
     @mock.patch("tap_bing_ads.create_sdk_client", return_value = '')
     @mock.patch("tap_bing_ads.CustomServiceClient")
@@ -94,17 +99,21 @@ class TestBackoffError(unittest.TestCase):
                                                     mock_write_schema, mock_get_bookmark,
                                                     mock_sobject_to_dict, mock_write_state,
                                                     mock_write_bookmark, mock_metrics, mock_write_records,
-                                                    mock_filter_selected_fields_many,mock_sleep):
+                                                    mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the socket timeout error 5 times.
+        Test that tap retry for 60 seconds on the socket timeout error.
         '''
         mock_get_account.side_effect = socket.timeout()
+        before_time = datetime.datetime.now()
         try:
             tap_bing_ads.sync_accounts_stream(['i1'], {})
         except socket.timeout:
             pass
-        # verify the code backed off and requested for 5 times
-        self.assertEqual(mock_get_account.call_count, 5)
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
         
     @mock.patch("tap_bing_ads.create_sdk_client", return_value = '')
     @mock.patch("tap_bing_ads.CustomServiceClient")
@@ -113,18 +122,22 @@ class TestBackoffError(unittest.TestCase):
                                                     mock_write_schema, mock_get_bookmark,
                                                     mock_sobject_to_dict, mock_write_state,
                                                     mock_write_bookmark, mock_metrics, mock_write_records,
-                                                    mock_filter_selected_fields_many,mock_sleep):
+                                                    mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the http timeout error 5 times.
+        Test that tap retry for 60 seconds on the http timeout error.
         '''
         with open('tests/base.py') as f:
             mock_get_account.side_effect = HTTPError('url', 408, 'Request Timeout', {}, f)
+        before_time = datetime.datetime.now()
         try:
             tap_bing_ads.sync_accounts_stream(['i1'], {})
         except HTTPError:
             pass
-        # verify the code backed off and requested for 5 times
-        self.assertEqual(mock_get_account.call_count, 5)
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
         
     @mock.patch("tap_bing_ads.create_sdk_client", return_value = '')
     @mock.patch("tap_bing_ads.CustomServiceClient")
@@ -133,18 +146,22 @@ class TestBackoffError(unittest.TestCase):
                                                     mock_write_schema, mock_get_bookmark,
                                                     mock_sobject_to_dict, mock_write_state,
                                                     mock_write_bookmark, mock_metrics, mock_write_records,
-                                                    mock_filter_selected_fields_many,mock_sleep):
+                                                    mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the 500 internal server error 5 times.
+        Test that tap retry for 60 seconds on the 500 internal server error.
         '''
         with open('tests/base.py') as f:
             mock_get_account.side_effect = HTTPError('url', 500, 'Internal Server Error', {}, f)
+        before_time = datetime.datetime.now()
         try:
             tap_bing_ads.sync_accounts_stream(['i1'], {})
         except HTTPError:
             pass
-        # verify the code backed off and requested for 5 times
-        self.assertEqual(mock_get_account.call_count, 5)
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
         
     @mock.patch("tap_bing_ads.create_sdk_client", return_value = '')
     @mock.patch("tap_bing_ads.CustomServiceClient")
@@ -153,18 +170,22 @@ class TestBackoffError(unittest.TestCase):
                                                 mock_write_schema, mock_get_bookmark,
                                                 mock_sobject_to_dict, mock_write_state, 
                                                 mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                mock_filter_selected_fields_many,mock_sleep):
+                                                mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the Transport error 5 times.
+        Test that tap retry for 60 seconds on the Transport error.
         '''
         with open('tests/base.py') as f:
             mock_get_account.side_effect = TransportError('url', 500, 'Internal Server Error')
+        before_time = datetime.datetime.now()
         try:
             tap_bing_ads.sync_accounts_stream(['i1'], {})
         except TransportError:
             pass
-        # verify the code backed off and requested for 5 times
-        self.assertEqual(mock_get_account.call_count, 5)
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
         
     @mock.patch("tap_bing_ads.create_sdk_client", return_value = '')
     @mock.patch("tap_bing_ads.CustomServiceClient")
@@ -173,12 +194,13 @@ class TestBackoffError(unittest.TestCase):
                                         mock_write_schema, mock_get_bookmark, 
                                         mock_sobject_to_dict, mock_write_state, 
                                         mock_write_bookmark, mock_metrics, mock_write_records, 
-                                        mock_filter_selected_fields_many,mock_sleep):
+                                        mock_filter_selected_fields_many):
         '''
         Test that tap does not retry on the 400 error.
         '''
         with open('tests/base.py') as f:
             mock_get_account.side_effect = HTTPError('url', 400, 'Bad Request', {}, f)
+        before_time = datetime.datetime.now()
         try:
             tap_bing_ads.sync_accounts_stream(['i1'], {})
         except HTTPError:
@@ -194,109 +216,134 @@ class TestBackoffError(unittest.TestCase):
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many,mock_sleep):
+                                                           mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the SSLEOFError 5 times.
+        Test that tap retry for 60 seconds on the SSLEOFError.
         '''
         with open('tests/base.py') as f:
             mock_get_account.side_effect = ssl.SSLEOFError('EOF occurred in violation of protocol')
+        before_time = datetime.datetime.now()
         try:
             tap_bing_ads.sync_accounts_stream(['i1'], {})
         except ssl.SSLEOFError:
             pass
-        # verify the code backed off and requested for 5 times
-        self.assertEqual(mock_get_account.call_count, 5)
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
         
     def test_connection_reset_error_sync_campaigns(self, mock_get_selected_fields, mock_get_core_schema, 
                                                         mock_write_schema, mock_get_bookmark, 
                                                         mock_sobject_to_dict, mock_write_state, 
                                                         mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                        mock_filter_selected_fields_many,mock_sleep):
+                                                        mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the connection reset error 5 times.
+        Test that tap retry for 60 seconds on the connection reset error.
         '''
         mock_client = MockClient(socket.error(104, 'Connection reset by peer'))
+        before_time = datetime.datetime.now()
         try:
             tap_bing_ads.sync_campaigns(mock_client, '', [])
         except ConnectionResetError:
             pass
-        # verify the code backed off and requested for 5 times
-        self.assertEqual(mock_client.call_count, 5)
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
         
     def test_socket_timeout_error_sync_campaigns(self, mock_get_selected_fields, mock_get_core_schema, 
                                                         mock_write_schema, mock_get_bookmark, 
                                                         mock_sobject_to_dict, mock_write_state, 
                                                         mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                        mock_filter_selected_fields_many,mock_sleep):
+                                                        mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the socket timeout error 5 times.
+        Test that tap retry for 60 seconds on the socket timeout error.
         '''
         mock_client = MockClient(socket.timeout())
+        before_time = datetime.datetime.now()
         try:
             tap_bing_ads.sync_campaigns(mock_client, '', [])
         except socket.timeout:
             pass
-        # verify the code backed off and requested for 5 times
-        self.assertEqual(mock_client.call_count, 5)
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
         
     def test_http_timeout_error_sync_campaigns(self, mock_get_selected_fields, mock_get_core_schema, 
                                                     mock_write_schema, mock_get_bookmark, 
                                                     mock_sobject_to_dict, mock_write_state, 
                                                     mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                    mock_filter_selected_fields_many,mock_sleep):
+                                                    mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the http timeout error 5 times.
+        Test that tap retry for 60 seconds on the http timeout error.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 408, 'Request Timeout', {}, f))
+        before_time = datetime.datetime.now()
         try:
             tap_bing_ads.sync_campaigns(mock_client, '', [])
         except HTTPError:
             pass
-        # verify the code backed off and requested for 5 times
-        self.assertEqual(mock_client.call_count, 5)
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
         
     def test_internal_server_error_sync_campaigns(self, mock_get_selected_fields, mock_get_core_schema, 
                                                         mock_write_schema, mock_get_bookmark, 
                                                         mock_sobject_to_dict, mock_write_state, 
                                                         mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                        mock_filter_selected_fields_many,mock_sleep):
+                                                        mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the 500 internal server error 5 times.
+        Test that tap retry for 60 seconds on the 500 internal server error.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 500, 'Internal Server Error', {}, f))
+        before_time = datetime.datetime.now()
         try:
             tap_bing_ads.sync_campaigns(mock_client, '', [])
         except HTTPError:
             pass
-        # verify the code backed off and requested for 5 times
-        self.assertEqual(mock_client.call_count, 5)
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
         
     def test_transport_server_error_sync_campaigns(self, mock_get_selected_fields, mock_get_core_schema, 
                                                         mock_write_schema, mock_get_bookmark, 
                                                         mock_sobject_to_dict, mock_write_state, 
                                                         mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                        mock_filter_selected_fields_many,mock_sleep):
+                                                        mock_filter_selected_fields_many):
         with open('tests/base.py') as f:
             mock_client = MockClient(TransportError('url', 500, 'Internal Server Error'))
+        before_time = datetime.datetime.now()
         try:
             tap_bing_ads.sync_campaigns(mock_client, '', [])
         except TransportError:
             pass
-        # verify the code backed off and requested for 5 times
-        self.assertEqual(mock_client.call_count, 5)
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
         
     def test_400_error_sync_campaigns(self, mock_get_selected_fields, mock_get_core_schema, 
                                             mock_write_schema, mock_get_bookmark, 
                                             mock_sobject_to_dict, mock_write_state, 
                                             mock_write_bookmark, mock_metrics, mock_write_records, 
-                                            mock_filter_selected_fields_many,mock_sleep):
+                                            mock_filter_selected_fields_many):
         '''
         Test that tap does not retry on the 400 error.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 400, 'Bad Request', {}, f))
+        before_time = datetime.datetime.now()
         try:
             tap_bing_ads.sync_campaigns(mock_client, '', [])
         except HTTPError:
@@ -308,111 +355,136 @@ class TestBackoffError(unittest.TestCase):
                                                 mock_write_schema, mock_get_bookmark, 
                                                 mock_sobject_to_dict, mock_write_state, 
                                                 mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                mock_filter_selected_fields_many,mock_sleep):
+                                                mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the SSLEOFError 5 times.
+        Test that tap retry for 60 seconds on the SSLEOFError.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(ssl.SSLEOFError('EOF occurred in violation of protocol'))
+        before_time = datetime.datetime.now()
         try:
             tap_bing_ads.sync_campaigns(mock_client, '', [])
         except ssl.SSLEOFError:
             pass
-        # verify the code backed off and requested for 5 times
-        self.assertEqual(mock_client.call_count, 5)
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
     def test_connection_reset_error_sync_ad_groups(self, mock_get_selected_fields, mock_get_core_schema, 
                                                         mock_write_schema, mock_get_bookmark, 
                                                         mock_sobject_to_dict, mock_write_state, 
                                                         mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                        mock_filter_selected_fields_many,mock_sleep):
+                                                        mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the connection reset error 5 times.
+        Test that tap retry for 60 seconds on the connection reset error.
         '''
         mock_client = MockClient(socket.error(104, 'Connection reset by peer'))
+        before_time = datetime.datetime.now()
         try:
             tap_bing_ads.sync_ad_groups(mock_client, '', ['dummy_campaign_id'], [])
         except ConnectionResetError:
             pass
-        # verify the code backed off and requested for 5 times
-        self.assertEqual(mock_client.call_count, 5)
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
         
     def test_socket_timeout_error_sync_ad_groups(self, mock_get_selected_fields, mock_get_core_schema, 
                                                         mock_write_schema, mock_get_bookmark, 
                                                         mock_sobject_to_dict, mock_write_state, 
                                                         mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                        mock_filter_selected_fields_many,mock_sleep):
+                                                        mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the socket timeout error 5 times.
+        Test that tap retry for 60 seconds on the socket timeout error.
         '''
         mock_client = MockClient(socket.timeout())
+        before_time = datetime.datetime.now()
         try:
             tap_bing_ads.sync_ad_groups(mock_client, '', ['dummy_campaign_id'], [])
         except socket.timeout:
             pass
-        # verify the code backed off and requested for 5 times
-        self.assertEqual(mock_client.call_count, 5)
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
         
     def test_http_timeout_error_sync_ad_groups(self, mock_get_selected_fields, mock_get_core_schema, 
                                                     mock_write_schema, mock_get_bookmark, 
                                                     mock_sobject_to_dict, mock_write_state, 
                                                     mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                    mock_filter_selected_fields_many,mock_sleep):
+                                                    mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the http timeout error 5 times.
+        Test that tap retry for 60 seconds on the http timeout error.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 408, 'Request Timeout', {}, f))
+        before_time = datetime.datetime.now()
         try:
             tap_bing_ads.sync_ad_groups(mock_client, '', ['dummy_campaign_id'], [])
         except HTTPError:
             pass
-        # verify the code backed off and requested for 5 times
-        self.assertEqual(mock_client.call_count, 5)
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
         
     def test_internal_server_error_sync_ad_groups(self, mock_get_selected_fields, mock_get_core_schema, 
                                                         mock_write_schema, mock_get_bookmark, 
                                                         mock_sobject_to_dict, mock_write_state, 
                                                         mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                        mock_filter_selected_fields_many,mock_sleep):
+                                                        mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the 500 internal server error 5 times.
+        Test that tap retry for 60 seconds on the 500 internal server error.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 500, 'Internal Server Error', {}, f))
+        before_time = datetime.datetime.now()
         try:
             tap_bing_ads.sync_ad_groups(mock_client, '', ['dummy_campaign_id'], [])
         except HTTPError:
             pass
-        # verify the code backed off and requested for 5 times
-        self.assertEqual(mock_client.call_count, 5)
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
         
     def test_transport_error_sync_ad_groups(self, mock_get_selected_fields, mock_get_core_schema, 
                                                         mock_write_schema, mock_get_bookmark, 
                                                         mock_sobject_to_dict, mock_write_state, 
                                                         mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                        mock_filter_selected_fields_many,mock_sleep):
+                                                        mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the Transport error 5 times.
+        Test that tap retry for 60 seconds on the Transport error.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(TransportError('url', 500, 'Internal Server Error'))
+        before_time = datetime.datetime.now()
         try:
             tap_bing_ads.sync_ad_groups(mock_client, '', ['dummy_campaign_id'], [])
         except TransportError:
             pass
-        # verify the code backed off and requested for 5 times
-        self.assertEqual(mock_client.call_count, 5)
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
         
     def test_400_error_sync_ad_groups(self, mock_get_selected_fields, mock_get_core_schema, 
                                                         mock_write_schema, mock_get_bookmark, 
                                                         mock_sobject_to_dict, mock_write_state, 
                                                         mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                        mock_filter_selected_fields_many,mock_sleep):
+                                                        mock_filter_selected_fields_many):
         '''
         Test that tap does not retry on the 400 error.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 400, 'Bad Request', {}, f))
+        before_time = datetime.datetime.now()
         try:
             tap_bing_ads.sync_ad_groups(mock_client, '', ['dummy_campaign_id'], [])
         except HTTPError:
@@ -424,112 +496,137 @@ class TestBackoffError(unittest.TestCase):
                                                 mock_write_schema, mock_get_bookmark, 
                                                 mock_sobject_to_dict, mock_write_state, 
                                                 mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                mock_filter_selected_fields_many,mock_sleep):
+                                                mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the SSLEOFError 5 times.
+        Test that tap retry for 60 seconds on the SSLEOFError.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(ssl.SSLEOFError('EOF occurred in violation of protocol'))
+        before_time = datetime.datetime.now()
         try:
             tap_bing_ads.sync_ad_groups(mock_client, '', ['dummy_campaign_id'], [])
         except ssl.SSLEOFError:
             pass
-        # verify the code backed off and requested for 5 times
-        self.assertEqual(mock_client.call_count, 5)        
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)        
         
     def test_connection_reset_error_sync_ads(self, mock_get_selected_fields, mock_get_core_schema, 
                                                 mock_write_schema, mock_get_bookmark, 
                                                 mock_sobject_to_dict, mock_write_state, 
                                                 mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                mock_filter_selected_fields_many,mock_sleep):
+                                                mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the connection reset error 5 times.
+        Test that tap retry for 60 seconds on the connection reset error.
         '''
         mock_client = MockClient(socket.error(104, 'Connection reset by peer'))
+        before_time = datetime.datetime.now()
         try:
             tap_bing_ads.sync_ads(mock_client, ['dummy_stream'], ['dummy_ad_id'])
         except ConnectionResetError:
             pass
-        # verify the code backed off and requested for 5 times
-        self.assertEqual(mock_client.call_count, 5)
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
         
     def test_socket_timeout_error_sync_ads(self, mock_get_selected_fields, mock_get_core_schema, 
                                                 mock_write_schema, mock_get_bookmark, 
                                                 mock_sobject_to_dict, mock_write_state, 
                                                 mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                mock_filter_selected_fields_many,mock_sleep):
+                                                mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the socket timeout error 5 times.
+        Test that tap retry for 60 seconds on the socket timeout error.
         '''
         mock_client = MockClient(socket.timeout())
+        before_time = datetime.datetime.now()
         try:
             tap_bing_ads.sync_ads(mock_client, ['dummy_stream'], ['dummy_ad_id'])
         except socket.timeout:
             pass
-        # verify the code backed off and requested for 5 times
-        self.assertEqual(mock_client.call_count, 5)
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
         
     def test_http_timeout_error_sync_ads(self, mock_get_selected_fields, mock_get_core_schema, 
                                                 mock_write_schema, mock_get_bookmark, 
                                                 mock_sobject_to_dict, mock_write_state, 
                                                 mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                smock_filter_selected_fields_many,mock_sleep):
+                                                smock_filter_selected_fields_many):
         '''
-        Test that tap retry on the http timeout error 5 times.
+        Test that tap retry for 60 seconds on the http timeout error.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 408, 'Request Timeout', {}, f))
+        before_time = datetime.datetime.now()
         try:
             tap_bing_ads.sync_ads(mock_client, ['dummy_stream'], ['dummy_ad_id'])
         except HTTPError:
             pass
-        # verify the code backed off and requested for 5 times
-        self.assertEqual(mock_client.call_count, 5)
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
         
     def test_internal_server_error_sync_ads(self, mock_get_selected_fields, mock_get_core_schema, 
                                                 mock_write_schema, mock_get_bookmark, 
                                                 mock_sobject_to_dict, mock_write_state, 
                                                 mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                mock_filter_selected_fields_many,mock_sleep):
+                                                mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the 500 internal server error 5 times.
+        Test that tap retry for 60 seconds on the 500 internal server error.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 500, 'Internal Server Error', {}, f))
+        before_time = datetime.datetime.now()
         try:
             tap_bing_ads.sync_ads(mock_client, ['dummy_stream'], ['dummy_ad_id'])
         except HTTPError:
             pass
-        # verify the code backed off and requested for 5 times
-        self.assertEqual(mock_client.call_count, 5)        
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)        
 
     def test_transport_error_sync_ads(self, mock_get_selected_fields, mock_get_core_schema, 
                                                 mock_write_schema, mock_get_bookmark, 
                                                 mock_sobject_to_dict, mock_write_state, 
                                                 mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                mock_filter_selected_fields_many,mock_sleep):
+                                                mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the Transport error 5 times.
+        Test that tap retry for 60 seconds on the Transport error.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(TransportError('url', 500, 'Internal Server Error'))
+        before_time = datetime.datetime.now()
         try:
             tap_bing_ads.sync_ads(mock_client, ['dummy_stream'], ['dummy_ad_id'])
         except TransportError:
             pass
-        # verify the code backed off and requested for 5 times
-        self.assertEqual(mock_client.call_count, 5) 
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60) 
 
     def test_400_error_sync_ads(self, mock_get_selected_fields, mock_get_core_schema, 
                                                 mock_write_schema, mock_get_bookmark, 
                                                 mock_sobject_to_dict, mock_write_state, 
                                                 mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                mock_filter_selected_fields_many,mock_sleep):
+                                                mock_filter_selected_fields_many):
         '''
         Test that tap does not retry on the 400 error.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 400, 'Bad Request', {}, f))
+        before_time = datetime.datetime.now()
         try:
             tap_bing_ads.sync_ads(mock_client, ['dummy_stream'], ['dummy_ad_id'])
         except HTTPError:
@@ -541,18 +638,22 @@ class TestBackoffError(unittest.TestCase):
                                         mock_write_schema, mock_get_bookmark, 
                                         mock_sobject_to_dict, mock_write_state, 
                                         mock_write_bookmark, mock_metrics, mock_write_records, 
-                                        mock_filter_selected_fields_many,mock_sleep):
+                                        mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the SSLEOFError 5 times.
+        Test that tap retry for 60 seconds on the SSLEOFError.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(ssl.SSLEOFError('EOF occurred in violation of protocol'))
+        before_time = datetime.datetime.now()
         try:
             tap_bing_ads.sync_ads(mock_client, ['dummy_stream'], ['dummy_ad_id'])
         except ssl.SSLEOFError:
             pass
-        # verify the code backed off and requested for 5 times
-        self.assertEqual(mock_client.call_count, 5)  
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)  
         
     @mock.patch("tap_bing_ads.build_report_request")
     def test_connection_reset_error_get_report_request_id(self, mock_build_report_request, 
@@ -560,18 +661,22 @@ class TestBackoffError(unittest.TestCase):
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many,mock_sleep):
+                                                           mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the connection reset error 5 times.
+        Test that tap retry for 60 seconds on the connection reset error.
         '''
         mock_client = MockClient(socket.error(104, 'Connection reset by peer'))
+        before_time = datetime.datetime.now()
         try:
             tap_bing_ads.get_report_request_id(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date', 'dummy_start_key',
                                                 force_refresh = True)
         except ConnectionResetError:
             pass
-        # verify the code backed off and requested for 5 times
-        self.assertEqual(mock_client.call_count, 5)
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
         
     @mock.patch("tap_bing_ads.build_report_request")
     def test_socket_timeout_error_get_report_request_id(self, mock_build_report_request, 
@@ -579,15 +684,19 @@ class TestBackoffError(unittest.TestCase):
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many,mock_sleep):
+                                                           mock_filter_selected_fields_many):
         mock_client = MockClient(socket.timeout())
+        before_time = datetime.datetime.now()
         try:
            tap_bing_ads.get_report_request_id(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date', 'dummy_start_key', 
                                               force_refresh = True)
         except socket.timeout:
             pass
-        # verify the code backed off and requested for 5 times
-        self.assertEqual(mock_client.call_count, 5)
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
         
     @mock.patch("tap_bing_ads.build_report_request")
     def test_http_timeout_error_get_report_request_id(self, mock_build_report_request, 
@@ -595,19 +704,23 @@ class TestBackoffError(unittest.TestCase):
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many,mock_sleep):
+                                                           mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the http timeout error 5 times.
+        Test that tap retry for 60 seconds on the http timeout error.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 408, 'Request Timeout', {}, f))
+        before_time = datetime.datetime.now()
         try:
             tap_bing_ads.get_report_request_id(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date', 'dummy_start_key',
                                                force_refresh = True)
         except HTTPError:
             pass
-        # verify the code backed off and requested for 5 times
-        self.assertEqual(mock_client.call_count, 5)
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
      
     @mock.patch("tap_bing_ads.build_report_request")   
     def test_internal_server_error_get_report_request_id(self, mock_build_report_request,
@@ -615,19 +728,23 @@ class TestBackoffError(unittest.TestCase):
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many,mock_sleep):
+                                                           mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the 500 internal server error 5 times.
+        Test that tap retry for 60 seconds on the 500 internal server error.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 500, 'Internal Server Error', {}, f))
+        before_time = datetime.datetime.now()
         try:
             tap_bing_ads.get_report_request_id(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date', 'dummy_start_key',
                                                force_refresh = True)
         except HTTPError:
             pass
-        # verify the code backed off and requested for 5 times
-        self.assertEqual(mock_client.call_count, 5)
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
 
     @mock.patch("tap_bing_ads.build_report_request")   
     def test_transport_error_get_report_request_id(self, mock_build_report_request,
@@ -635,19 +752,23 @@ class TestBackoffError(unittest.TestCase):
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many,mock_sleep):
+                                                           mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the Transport error 5 times.
+        Test that tap retry for 60 seconds on the Transport error.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(TransportError('url', 500, 'Internal Server Error'))
+        before_time = datetime.datetime.now()
         try:
             tap_bing_ads.get_report_request_id(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date', 'dummy_start_key',
                                                force_refresh = True)
         except TransportError:
             pass
-        # verify the code backed off and requested for 5 times
-        self.assertEqual(mock_client.call_count, 5)
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
         
     @mock.patch("tap_bing_ads.build_report_request")   
     def test_400_error_get_report_request_id(self, mock_build_report_request,
@@ -655,12 +776,13 @@ class TestBackoffError(unittest.TestCase):
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many,mock_sleep):
+                                                           mock_filter_selected_fields_many):
         '''
         Test that tap does not retry on the 400 error.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 400, 'Bad Request', {}, f))
+        before_time = datetime.datetime.now()
         try:
             tap_bing_ads.get_report_request_id(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date', 'dummy_start_key',
                                                force_refresh = True)
@@ -675,113 +797,138 @@ class TestBackoffError(unittest.TestCase):
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many,mock_sleep):
+                                                           mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the SSLEOFError 5 times.
+        Test that tap retry for 60 seconds on the SSLEOFError.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(ssl.SSLEOFError('EOF occurred in violation of protocol'))
+        before_time = datetime.datetime.now()
         try:
             tap_bing_ads.get_report_request_id(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date', 'dummy_start_key',
                                                force_refresh = True)
         except ssl.SSLEOFError:
             pass
-        # verify the code backed off and requested for 5 times
-        self.assertEqual(mock_client.call_count, 5)
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
                 
     def test_connection_reset_error_build_report_request(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many,mock_sleep):
+                                                           mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the connection reset error 5 times.
+        Test that tap retry for 60 seconds on the connection reset error.
         '''
         mock_client = MockClient(socket.error(104, 'Connection reset by peer'))
+        before_time = datetime.datetime.now()
         try:
             tap_bing_ads.build_report_request(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date')
         except ConnectionResetError:
             pass
-        # verify the code backed off and requested for 5 times
-        self.assertEqual(mock_client.call_count, 5)
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
         
     def test_socket_timeout_error_build_report_request(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many,mock_sleep):
+                                                           mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the socket timeout error 5 times.
+        Test that tap retry for 60 seconds on the socket timeout error.
         '''
         mock_client = MockClient(socket.timeout())
+        before_time = datetime.datetime.now()
         try:
            tap_bing_ads.build_report_request(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date')
         except socket.timeout:
             pass
-        # verify the code backed off and requested for 5 times
-        self.assertEqual(mock_client.call_count, 5)
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
         
     def test_http_timeout_error_build_report_request(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many,mock_sleep):
+                                                           mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the http timeout error 5 times.
+        Test that tap retry for 60 seconds on the http timeout error.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 408, 'Request Timeout', {}, f))
+        before_time = datetime.datetime.now()
         try:
             tap_bing_ads.build_report_request(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date')
         except HTTPError:
             pass
-        # verify the code backed off and requested for 5 times
-        self.assertEqual(mock_client.call_count, 5)
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
      
     def test_internal_server_error_build_report_request(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many,mock_sleep):
+                                                           mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the 500 internal server error 5 times.
+        Test that tap retry for 60 seconds on the 500 internal server error.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 500, 'Internal Server Error', {}, f))
+        before_time = datetime.datetime.now()
         try:
             tap_bing_ads.build_report_request(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date')
         except HTTPError:
             pass
-        # verify the code backed off and requested for 5 times
-        self.assertEqual(mock_client.call_count, 5)
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
         
     def test_transport_error_build_report_request(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many,mock_sleep):
+                                                           mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the Transport error 5 times.
+        Test that tap retry for 60 seconds on the Transport error.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(TransportError('url', 500, 'Internal Server Error'))
+        before_time = datetime.datetime.now()
         try:
             tap_bing_ads.build_report_request(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date')
         except TransportError:
             pass
-        # verify the code backed off and requested for 5 times
-        self.assertEqual(mock_client.call_count, 5)
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
         
     def test_400_error_build_report_request(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many,mock_sleep):
+                                                           mock_filter_selected_fields_many):
         '''
         Test that tap does not retry on the 400 error.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 400, 'Bad Request', {}, f))
+        before_time = datetime.datetime.now()
         try:
             tap_bing_ads.build_report_request(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date')
         except HTTPError:
@@ -793,112 +940,137 @@ class TestBackoffError(unittest.TestCase):
                                                     mock_write_schema, mock_get_bookmark, 
                                                     mock_sobject_to_dict, mock_write_state, 
                                                     mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                    mock_filter_selected_fields_many,mock_sleep):
+                                                    mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the SSLEOFError 5 times.
+        Test that tap retry for 60 seconds on the SSLEOFError.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(ssl.SSLEOFError('EOF occurred in violation of protocol'))
+        before_time = datetime.datetime.now()
         try:
             tap_bing_ads.build_report_request(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date')
         except ssl.SSLEOFError:
             pass
-        # verify the code backed off and requested for 5 times
-        self.assertEqual(mock_client.call_count, 5)
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
                
     def test_connection_reset_error_get_report_schema(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many,mock_sleep):
+                                                           mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the connection reset error 5 times.
+        Test that tap retry for 60 seconds on the connection reset error.
         '''
         mock_client = MockClient(socket.error(104, 'Connection reset by peer'))
+        before_time = datetime.datetime.now()
         try:
             tap_bing_ads.get_report_schema(mock_client, '')
         except ConnectionResetError:
             pass
-        # verify the code backed off and requested for 5 times
-        self.assertEqual(mock_client.call_count, 5)
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
         
     def test_socket_timeout_error_get_report_schema(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many,mock_sleep):
+                                                           mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the socket timeout error 5 times.
+        Test that tap retry for 60 seconds on the socket timeout error.
         '''
         mock_client = MockClient(socket.timeout())
+        before_time = datetime.datetime.now()
         try:
            tap_bing_ads.get_report_schema(mock_client, '')
         except socket.timeout:
             pass
-        # verify the code backed off and requested for 5 times
-        self.assertEqual(mock_client.call_count, 5)
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
         
     def test_http_timeout_error_get_report_schema(self, mock_get_selected_fields, mock_get_core_schema, 
                                                         mock_write_schema, mock_get_bookmark, 
                                                         mock_sobject_to_dict, mock_write_state, 
                                                         mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                        mock_filter_selected_fields_many,mock_sleep):
+                                                        mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the http timeout error 5 times.
+        Test that tap retry for 60 seconds on the http timeout error.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 408, 'Request Timeout', {}, f))
+        before_time = datetime.datetime.now()
         try:
             tap_bing_ads.get_report_schema(mock_client, '')
         except HTTPError:
             pass
-        # verify the code backed off and requested for 5 times
-        self.assertEqual(mock_client.call_count, 5)
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
      
     def test_internal_server_error_get_report_schema(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many,mock_sleep):
+                                                           mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the 500 internal server error 5 times.
+        Test that tap retry for 60 seconds on the 500 internal server error.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 500, 'Internal Server Error', {}, f))
+        before_time = datetime.datetime.now()
         try:
             tap_bing_ads.get_report_schema(mock_client, '')
         except HTTPError:
             pass
-        # verify the code backed off and requested for 5 times
-        self.assertEqual(mock_client.call_count, 5)
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
 
     def test_transport_error_get_report_schema(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many,mock_sleep):
+                                                           mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the Transport error 5 times.
+        Test that tap retry for 60 seconds on the Transport error.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(TransportError('url', 500, 'Internal Server Error'))
+        before_time = datetime.datetime.now()
         try:
             tap_bing_ads.get_report_schema(mock_client, '')
         except TransportError:
             pass
-        # verify the code backed off and requested for 5 times
-        self.assertEqual(mock_client.call_count, 5)
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
 
     def test_400_error_get_report_schema(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many,mock_sleep):
+                                                           mock_filter_selected_fields_many):
         '''
         Test that tap does not retry on the 400 error.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 400, 'Bad Request', {}, f))
+        before_time = datetime.datetime.now()
         try:
             tap_bing_ads.get_report_schema(mock_client, '')
         except HTTPError:
@@ -910,112 +1082,137 @@ class TestBackoffError(unittest.TestCase):
                                                 mock_write_schema, mock_get_bookmark, 
                                                 mock_sobject_to_dict, mock_write_state, 
                                                 mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                mock_filter_selected_fields_many,mock_sleep):
+                                                mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the SSLEOFError 5 times.
+        Test that tap retry for 60 seconds on the SSLEOFError.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(ssl.SSLEOFError('EOF occurred in violation of protocol'))
+        before_time = datetime.datetime.now()
         try:
             tap_bing_ads.get_report_schema(mock_client, '')
         except ssl.SSLEOFError:
             pass
-        # verify the code backed off and requested for 5 times
-        self.assertEqual(mock_client.call_count, 5)
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
                 
     def test_connection_reset_error_get_type_map(self, mock_get_selected_fields, mock_get_core_schema, 
                                                     mock_write_schema, mock_get_bookmark, 
                                                     mock_sobject_to_dict, mock_write_state, 
                                                     mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                    mock_filter_selected_fields_many,mock_sleep):
+                                                    mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the connection reset error 5 times.
+        Test that tap retry for 60 seconds on the connection reset error.
         '''
         mock_client = MockClient(socket.error(104, 'Connection reset by peer'))
+        before_time = datetime.datetime.now()
         try:
             tap_bing_ads.get_type_map(mock_client)
         except ConnectionResetError:
             pass
-        # verify the code backed off and requested for 5 times
-        self.assertEqual(mock_client.call_count, 5)
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
         
     def test_socket_timeout_error_get_type_map(self, mock_get_selected_fields, mock_get_core_schema, 
                                                     mock_write_schema, mock_get_bookmark, 
                                                     mock_sobject_to_dict, mock_write_state, 
                                                     mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                    mock_filter_selected_fields_many,mock_sleep):
+                                                    mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the socket timeout error 5 times.
+        Test that tap retry for 60 seconds on the socket timeout error.
         '''
         mock_client = MockClient(socket.timeout())
+        before_time = datetime.datetime.now()
         try:
            tap_bing_ads.get_type_map(mock_client)
         except socket.timeout:
             pass
-        # verify the code backed off and requested for 5 times
-        self.assertEqual(mock_client.call_count, 5)
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
         
     def test_http_timeout_error_get_type_map(self, mock_get_selected_fields, mock_get_core_schema, 
                                                 mock_write_schema, mock_get_bookmark, 
                                                 mock_sobject_to_dict, mock_write_state, 
                                                 mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                mock_filter_selected_fields_many,mock_sleep):
+                                                mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the http timeout error 5 times.
+        Test that tap retry for 60 seconds on the http timeout error.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 408, 'Request Timeout', {}, f))
+        before_time = datetime.datetime.now()
         try:
             tap_bing_ads.get_type_map(mock_client)
         except HTTPError:
             pass
-        # verify the code backed off and requested for 5 times
-        self.assertEqual(mock_client.call_count, 5)
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
      
     def test_internal_server_error_get_type_map(self, mock_get_selected_fields, mock_get_core_schema, 
                                                     mock_write_schema, mock_get_bookmark, 
                                                     mock_sobject_to_dict, mock_write_state, 
                                                     mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                    mock_filter_selected_fields_many,mock_sleep):
+                                                    mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the 500 internal server error 5 times.
+        Test that tap retry for 60 seconds on the 500 internal server error.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 500, 'Internal Server Error', {}, f))
+        before_time = datetime.datetime.now()
         try:
             tap_bing_ads.get_type_map(mock_client)
         except HTTPError:
             pass
-        # verify the code backed off and requested for 5 times
-        self.assertEqual(mock_client.call_count, 5)
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
 
     def test_transport_error_get_type_map(self, mock_get_selected_fields, mock_get_core_schema, 
                                                     mock_write_schema, mock_get_bookmark, 
                                                     mock_sobject_to_dict, mock_write_state, 
                                                     mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                    mock_filter_selected_fields_many,mock_sleep):
+                                                    mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the Transport error 5 times.
+        Test that tap retry for 60 seconds on the Transport error.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(TransportError('url', 500, 'Internal Server Error'))
+        before_time = datetime.datetime.now()
         try:
             tap_bing_ads.get_type_map(mock_client)
         except TransportError:
             pass
-        # verify the code backed off and requested for 5 times
-        self.assertEqual(mock_client.call_count, 5)
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
         
     def test_400_error_get_type_map(self, mock_get_selected_fields, mock_get_core_schema, 
                                                     mock_write_schema, mock_get_bookmark, 
                                                     mock_sobject_to_dict, mock_write_state, 
                                                     mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                    mock_filter_selected_fields_many,mock_sleep):
+                                                    mock_filter_selected_fields_many):
         '''
         Test that tap does not retry on the 400 error.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 400, 'Bad Request', {}, f))
+        before_time = datetime.datetime.now()
         try:
             tap_bing_ads.get_type_map(mock_client)
         except HTTPError:
@@ -1027,112 +1224,137 @@ class TestBackoffError(unittest.TestCase):
                                             mock_write_schema, mock_get_bookmark, 
                                             mock_sobject_to_dict, mock_write_state, 
                                             mock_write_bookmark, mock_metrics, mock_write_records, 
-                                            mock_filter_selected_fields_many,mock_sleep):
+                                            mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the SSLEOFError 5 times.
+        Test that tap retry for 60 seconds on the SSLEOFError.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(ssl.SSLEOFError('EOF occurred in violation of protocol'))
+        before_time = datetime.datetime.now()
         try:
             tap_bing_ads.get_type_map(mock_client)
         except ssl.SSLEOFError:
             pass
-        # verify the code backed off and requested for 5 times
-        self.assertEqual(mock_client.call_count, 5)
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
 
     async def test_connection_reset_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many,mock_sleep):
+                                                           mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the connection reset error 5 times.
+        Test that tap retry for 60 seconds on the connection reset error.
         '''
         mock_client = MockClient(socket.error(104, 'Connection reset by peer'))
+        before_time = datetime.datetime.now()
         try:
             await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
         except ConnectionResetError:
             pass
-        # verify the code backed off and requested for 5 times
-        self.assertEqual(mock_client.call_count, 5)
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
         
     async def test_socket_timeout_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many,mock_sleep):
+                                                           mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the socket timeout error 5 times.
+        Test that tap retry for 60 seconds on the socket timeout error.
         '''
         mock_client = MockClient(socket.timeout())
+        before_time = datetime.datetime.now()
         try:
            await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
         except socket.timeout:
             pass
-        # verify the code backed off and requested for 5 times
-        self.assertEqual(mock_client.call_count, 5)
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
         
     async def test_http_timeout_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
                                                         mock_write_schema, mock_get_bookmark, 
                                                         mock_sobject_to_dict, mock_write_state, 
                                                         mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                        mock_filter_selected_fields_many,mock_sleep):
+                                                        mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the http timeout error 5 times.
+        Test that tap retry for 60 seconds on the http timeout error.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 408, 'Request Timeout', {}, f))
+        before_time = datetime.datetime.now()
         try:
             await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
         except HTTPError:
             pass
-        # verify the code backed off and requested for 5 times
-        self.assertEqual(mock_client.call_count, 5)
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
      
     async def test_internal_server_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many,mock_sleep):
+                                                           mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the 500 internal server error 5 times.
+        Test that tap retry for 60 seconds on the 500 internal server error.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 500, 'Internal Server Error', {}, f))
+        before_time = datetime.datetime.now()
         try:
             await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
         except HTTPError:
             pass
-        # verify the code backed off and requested for 5 times
-        self.assertEqual(mock_client.call_count, 5)
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
             
     async def test_transport_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many,mock_sleep):
+                                                           mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the Transport error 5 times.
+        Test that tap retry for 60 seconds on the Transport error.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(TransportError('url', 500, 'Internal Server Error'))
+        before_time = datetime.datetime.now()
         try:
             await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
         except TransportError:
             pass
-        # verify the code backed off and requested for 5 times
-        self.assertEqual(mock_client.call_count, 5)
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
         
     async def test_400_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many,mock_sleep):
+                                                           mock_filter_selected_fields_many):
         '''
         Test that tap does not retry on the 400 error.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 400, 'Bad Request', {}, f))
+        before_time = datetime.datetime.now()
         try:
             await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
         except HTTPError:
@@ -1144,18 +1366,22 @@ class TestBackoffError(unittest.TestCase):
                                                     mock_write_schema, mock_get_bookmark, 
                                                     mock_sobject_to_dict, mock_write_state, 
                                                     mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                    mock_filter_selected_fields_many,mock_sleep):
+                                                    mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the SSLEOFError 5 times.
+        Test that tap retry for 60 seconds on the SSLEOFError.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(ssl.SSLEOFError('EOF occurred in violation of protocol'))
+        before_time = datetime.datetime.now()
         try:
             s = await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
         except ssl.SSLEOFError:
             pass
-        # verify the code backed off and requested for 5 times
-        self.assertEqual(mock_client.call_count, 5)
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
         
     @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
     @mock.patch("bingads.OAuthWebAuthCodeGrant.request_oauth_tokens_by_refresh_token")
@@ -1166,15 +1392,19 @@ class TestBackoffError(unittest.TestCase):
                                                         mock_write_schema, mock_get_bookmark, 
                                                         mock_sobject_to_dict, mock_write_state, 
                                                         mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                        mock_filter_selected_fields_many,mock_sleep):
+                                                        mock_filter_selected_fields_many):
         mock_oauth.return_value = ''
         mock_client.side_effect = socket.error(104, 'Connection reset by peer')
+        before_time = datetime.datetime.now()
         try:
             tap_bing_ads.create_sdk_client('dummy_service', {})
         except ConnectionResetError:
             pass
-        # verify the code backed off and requested for 5 times
-        self.assertEqual(mock_oauth.call_count, 5)
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
         
     @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
     @mock.patch("bingads.OAuthWebAuthCodeGrant.request_oauth_tokens_by_refresh_token")
@@ -1185,18 +1415,22 @@ class TestBackoffError(unittest.TestCase):
                                                     mock_write_schema, mock_get_bookmark, 
                                                     mock_sobject_to_dict, mock_write_state, 
                                                     mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                    mock_filter_selected_fields_many,mock_sleep):
+                                                    mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the socket timeout error 5 times.
+        Test that tap retry for 60 seconds on the socket timeout error.
         '''
         mock_oauth.return_value = ''
         mock_client.side_effect = socket.timeout()
+        before_time = datetime.datetime.now()
         try:
             tap_bing_ads.create_sdk_client('dummy_service', {})
         except socket.timeout:
             pass
-        # verify the code backed off and requested for 5 times
-        self.assertEqual(mock_oauth.call_count, 5)
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
         
     @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
     @mock.patch("bingads.OAuthWebAuthCodeGrant.request_oauth_tokens_by_refresh_token")
@@ -1207,19 +1441,23 @@ class TestBackoffError(unittest.TestCase):
                                                         mock_write_schema, mock_get_bookmark, 
                                                         mock_sobject_to_dict, mock_write_state, 
                                                         mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                        mock_filter_selected_fields_many,mock_sleep):
+                                                        mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the http timeout error 5 times.
+        Test that tap retry for 60 seconds on the http timeout error.
         '''
         mock_oauth.return_value = ''
         with open('tests/base.py') as f:
             mock_client.side_effect = HTTPError('url', 408, 'Request Timeout', {}, f)
+        before_time = datetime.datetime.now()
         try:
             tap_bing_ads.create_sdk_client('dummy_service', {})
         except HTTPError:
             pass
-        # verify the code backed off and requested for 5 times
-        self.assertEqual(mock_oauth.call_count, 5)
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
         
     @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
     @mock.patch("bingads.OAuthWebAuthCodeGrant.request_oauth_tokens_by_refresh_token")
@@ -1230,19 +1468,23 @@ class TestBackoffError(unittest.TestCase):
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many,mock_sleep):
+                                                           mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the 500 internal server error 5 times.
+        Test that tap retry for 60 seconds on the 500 internal server error.
         '''
         mock_oauth.return_value = ''
         with open('tests/base.py') as f:
             mock_client.side_effect = HTTPError('url', 500, 'Internal Server Error', {}, f)
+        before_time = datetime.datetime.now()
         try:
             tap_bing_ads.create_sdk_client('dummy_service', {})
         except HTTPError:
             pass
-        # verify the code backed off and requested for 5 times
-        self.assertEqual(mock_oauth.call_count, 5)
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
         
     @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
     @mock.patch("bingads.OAuthWebAuthCodeGrant.request_oauth_tokens_by_refresh_token")
@@ -1253,19 +1495,23 @@ class TestBackoffError(unittest.TestCase):
                                                     mock_write_schema, mock_get_bookmark, 
                                                     mock_sobject_to_dict, mock_write_state, 
                                                     mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                    mock_filter_selected_fields_many,mock_sleep):
+                                                    mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the Transport error 5 times.
+        Test that tap retry for 60 seconds on the Transport error.
         '''
         mock_oauth.return_value = ''
         with open('tests/base.py') as f:
             mock_client.side_effect = TransportError('url', 500, 'Internal Server Error')
+        before_time = datetime.datetime.now()
         try:
             tap_bing_ads.create_sdk_client('dummy_service', {})
         except TransportError:
             pass
-        # verify the code backed off and requested for 5 times
-        self.assertEqual(mock_oauth.call_count, 5)
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
         
     @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
     @mock.patch("bingads.OAuthWebAuthCodeGrant.request_oauth_tokens_by_refresh_token")
@@ -1276,13 +1522,14 @@ class TestBackoffError(unittest.TestCase):
                                                 mock_write_schema, mock_get_bookmark, 
                                                 mock_sobject_to_dict, mock_write_state, 
                                                 mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                mock_filter_selected_fields_many,mock_sleep):
+                                                mock_filter_selected_fields_many):
         '''
         Test that tap does not retry on the 400 error.
         '''
         mock_oauth.return_value = ''
         with open('tests/base.py') as f:
             mock_client.side_effect = HTTPError('url', 400, 'Bad Request', {}, f)
+        before_time = datetime.datetime.now()
         try:
             tap_bing_ads.create_sdk_client('dummy_service', {})
         except HTTPError:
@@ -1300,19 +1547,23 @@ class TestBackoffError(unittest.TestCase):
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many,mock_sleep):
+                                                           mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the SSLEOFError 5 times.
+        Test that tap retry for 60 seconds on the SSLEOFError.
         '''
         mock_oauth.return_value = ''
         with open('tests/base.py') as f:
             mock_client.side_effect = ssl.SSLEOFError('EOF occurred in violation of protocol')
+        before_time = datetime.datetime.now()
         try:
             tap_bing_ads.create_sdk_client('dummy_service', {})
         except ssl.SSLEOFError:
             pass
-        # verify the code backed off and requested for 5 times
-        self.assertEqual(mock_oauth.call_count, 5)
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
         
     
     @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
@@ -1324,19 +1575,23 @@ class TestBackoffError(unittest.TestCase):
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many,mock_sleep):
+                                                           mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the 408 Request Timeout Exception of 5 times.
+        Test that tap retry for 60 seconds on the 408 Request Timeout Exception of.
         '''
         mock_oauth.return_value = ''
         with open('tests/base.py') as f:
             mock_client.side_effect = Exception((408, 'Request Timeout'))
+        before_time = datetime.datetime.now()
         try:
             tap_bing_ads.create_sdk_client('dummy_service', {})
         except Exception:
             pass
-        # verify the code backed off and requested for 5 times
-        self.assertEqual(mock_oauth.call_count, 5)
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
         
     @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
     @mock.patch("bingads.OAuthWebAuthCodeGrant.request_oauth_tokens_by_refresh_token")
@@ -1347,16 +1602,17 @@ class TestBackoffError(unittest.TestCase):
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many,mock_sleep):
+                                                           mock_filter_selected_fields_many):
         '''
         Test that tap does not retry on the 400 Bad reques Exception.
         '''
         mock_oauth.return_value = ''
         with open('tests/base.py') as f:
             mock_client.side_effect = Exception((400, 'Bad request'))
+        before_time = datetime.datetime.now()
         try:
             tap_bing_ads.create_sdk_client('dummy_service', {})
         except Exception:
             pass
-        # verify the code backed off and requested for 5 times
+        # verify the code backed off and requested for
         self.assertEqual(mock_oauth.call_count, 1)

--- a/tests/unittests/test_backoff_error_handling.py
+++ b/tests/unittests/test_backoff_error_handling.py
@@ -2,7 +2,7 @@ import unittest
 import socket
 from unittest import mock
 import tap_bing_ads
-from urllib.error import HTTPError
+from urllib.error import HTTPError, URLError
 import ssl
 from suds.transport import TransportError
 import datetime
@@ -206,7 +206,30 @@ class TestBackoffError(unittest.TestCase):
             pass
         # verify the code raise error without backoff
         self.assertEqual(mock_get_account.call_count, 1)
+
+    @mock.patch("tap_bing_ads.create_sdk_client", return_value = '')
+    @mock.patch("tap_bing_ads.CustomServiceClient")
+    def test_url_error_get_account(self, mock_get_account, mock_create_sdk_client, 
+                                        mock_get_selected_fields, mock_get_core_schema, 
+                                        mock_write_schema, mock_get_bookmark, 
+                                        mock_sobject_to_dict, mock_write_state, 
+                                        mock_write_bookmark, mock_metrics, mock_write_records, 
+                                        mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the URLError.
+        '''
+        mock_get_account.side_effect  = URLError("<urlopen error [Errno 104] Connection reset by peer>")
         
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.sync_accounts_stream(['i1'], {})
+        except URLError:
+            pass
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
        
     @mock.patch("tap_bing_ads.create_sdk_client", return_value = '')
     @mock.patch("tap_bing_ads.CustomServiceClient")
@@ -349,7 +372,25 @@ class TestBackoffError(unittest.TestCase):
             pass
         # verify the code raise error without backoff
         self.assertEqual(mock_client.call_count, 1)
+    
+    def test_url_error_sync_campaigns(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                        mock_write_schema, mock_get_bookmark, 
+                                                        mock_sobject_to_dict, mock_write_state, 
+                                                        mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                        mock_filter_selected_fields_many):
+        mock_client = MockClient(URLError("<urlopen error [Errno 104] Connection reset by peer>"))
         
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.sync_campaigns(mock_client, '', [])
+        except URLError:
+            pass
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
+
     def test_ssl_eof_error_sync_campaigns(self, mock_get_selected_fields, mock_get_core_schema, 
                                                 mock_write_schema, mock_get_bookmark, 
                                                 mock_sobject_to_dict, mock_write_state, 
@@ -490,7 +531,28 @@ class TestBackoffError(unittest.TestCase):
             pass
         # verify the code raise error without backoff
         self.assertEqual(mock_client.call_count, 1)
+
+    def test_url_error_sync_ad_groups(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                        mock_write_schema, mock_get_bookmark, 
+                                                        mock_sobject_to_dict, mock_write_state, 
+                                                        mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                        mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the URLError.
+        '''
+        mock_client = MockClient(URLError("<urlopen error [Errno 104] Connection reset by peer>"))
         
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.sync_ad_groups(mock_client, '', ['dummy_campaign_id'], [])
+        except URLError:
+            pass
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
+ 
     def test_ssl_eof_error_sync_ad_groups(self, mock_get_selected_fields, mock_get_core_schema, 
                                                 mock_write_schema, mock_get_bookmark, 
                                                 mock_sobject_to_dict, mock_write_state, 
@@ -632,7 +694,28 @@ class TestBackoffError(unittest.TestCase):
             pass
         # verify the code raise error without backoff
         self.assertEqual(mock_client.call_count, 1) 
+
+    def test_url_error_sync_ads(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                mock_write_schema, mock_get_bookmark, 
+                                                mock_sobject_to_dict, mock_write_state, 
+                                                mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the URLError.
+        '''
+        mock_client = MockClient(URLError("<urlopen error [Errno 104] Connection reset by peer>"))
         
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.sync_ads(mock_client, ['dummy_stream'], ['dummy_ad_id'])
+        except URLError:
+            pass
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60) 
+
     def test_ssl_eof_error_sync_ads(self, mock_get_selected_fields, mock_get_core_schema, 
                                         mock_write_schema, mock_get_bookmark, 
                                         mock_sobject_to_dict, mock_write_state, 
@@ -789,7 +872,31 @@ class TestBackoffError(unittest.TestCase):
             pass
         # verify the code raise error without backoff
         self.assertEqual(mock_client.call_count, 1)
+
+    @mock.patch("tap_bing_ads.build_report_request")   
+    def test_url_error_get_report_request_id(self, mock_build_report_request,
+                                                           mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the URLError.
+        '''
+        mock_client = MockClient(URLError("<urlopen error [Errno 104] Connection reset by peer>"))
         
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.get_report_request_id(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date', 'dummy_start_key',
+                                               force_refresh = True)
+        except URLError:
+            pass
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
+    
     @mock.patch("tap_bing_ads.build_report_request")   
     def test_ssl_eof_error_get_report_request_id(self, mock_build_report_request,
                                                            mock_get_selected_fields, mock_get_core_schema, 
@@ -934,7 +1041,27 @@ class TestBackoffError(unittest.TestCase):
             pass
         # verify the code raise error without backoff
         self.assertEqual(mock_client.call_count, 1)
-        
+
+    def test_url_error_build_report_request(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the URLError.
+        '''
+        mock_client = MockClient(URLError("<urlopen error [Errno 104] Connection reset by peer>"))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.build_report_request(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date')
+        except URLError:
+            pass
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)   
+    
     def test_ssl_eof_error_build_report_request(self, mock_get_selected_fields, mock_get_core_schema, 
                                                     mock_write_schema, mock_get_bookmark, 
                                                     mock_sobject_to_dict, mock_write_state, 
@@ -1076,7 +1203,28 @@ class TestBackoffError(unittest.TestCase):
             pass
         # verify the code raise error without backoff
         self.assertEqual(mock_client.call_count, 1)
-         
+
+    def test_url_error_get_report_schema(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the Transport error.
+        '''
+        mock_client = MockClient(URLError("<urlopen error [Errno 104] Connection reset by peer>"))
+        
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.get_report_schema(mock_client, '')
+        except URLError:
+            pass
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
+    
     def test_ssl_eof_error_get_report_schema(self, mock_get_selected_fields, mock_get_core_schema, 
                                                 mock_write_schema, mock_get_bookmark, 
                                                 mock_sobject_to_dict, mock_write_state, 
@@ -1218,7 +1366,28 @@ class TestBackoffError(unittest.TestCase):
             pass
         # verify the code raise error without backoff
         self.assertEqual(mock_client.call_count, 1)
+
+    def test_url_error_get_type_map(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                    mock_write_schema, mock_get_bookmark, 
+                                                    mock_sobject_to_dict, mock_write_state, 
+                                                    mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                    mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the URLError.
+        '''
+        mock_client = MockClient(URLError("<urlopen error [Errno 104] Connection reset by peer>"))
         
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.get_type_map(mock_client)
+        except URLError:
+            pass
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
+   
     def test_ssl_eof_error_get_type_map(self, mock_get_selected_fields, mock_get_core_schema, 
                                             mock_write_schema, mock_get_bookmark, 
                                             mock_sobject_to_dict, mock_write_state, 
@@ -1360,7 +1529,28 @@ class TestBackoffError(unittest.TestCase):
             pass
         # verify the code raise error without backoff
         self.assertEqual(mock_client.call_count, 1)
+
+    async def test_url_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the URLError.
+        '''
+        mock_client = MockClient(URLError("<urlopen error [Errno 104] Connection reset by peer>"))
         
+        before_time = datetime.datetime.now()
+        try:
+            await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
+        except URLError:
+            pass
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
+
     async def test_ssl_eof_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
                                                     mock_write_schema, mock_get_bookmark, 
                                                     mock_sobject_to_dict, mock_write_state, 
@@ -1557,6 +1747,33 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.create_sdk_client('dummy_service', {})
         except ssl.SSLEOFError:
+            pass
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
+
+    @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
+    @mock.patch("bingads.OAuthWebAuthCodeGrant.request_oauth_tokens_by_refresh_token")
+    @mock.patch("bingads.AuthorizationData", return_value = '')
+    @mock.patch("tap_bing_ads.CustomServiceClient")
+    def test_url_error_create_sdk_client(self, mock_client, mock_authorization_data, mock_oauth, mock_config,
+                                                    mock_get_selected_fields, mock_get_core_schema, 
+                                                    mock_write_schema, mock_get_bookmark, 
+                                                    mock_sobject_to_dict, mock_write_state, 
+                                                    mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                    mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the Transport error.
+        '''
+        mock_oauth.return_value = ''
+        mock_client.side_effect = URLError("<urlopen error [Errno 104] Connection reset by peer>")
+        
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.create_sdk_client('dummy_service', {})
+        except URLError:
             pass
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()

--- a/tests/unittests/test_backoff_error_handling.py
+++ b/tests/unittests/test_backoff_error_handling.py
@@ -88,7 +88,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
         
     @mock.patch("tap_bing_ads.create_sdk_client", return_value = '')
@@ -111,7 +111,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
         
     @mock.patch("tap_bing_ads.create_sdk_client", return_value = '')
@@ -135,7 +135,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
         
     @mock.patch("tap_bing_ads.create_sdk_client", return_value = '')
@@ -159,7 +159,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
         
     @mock.patch("tap_bing_ads.create_sdk_client", return_value = '')
@@ -173,8 +173,7 @@ class TestBackoffError(unittest.TestCase):
         '''
         Test that tap retry for 60 seconds on the Transport error.
         '''
-        with open('tests/base.py') as f:
-            mock_get_account.side_effect = TransportError('url', 500, 'Internal Server Error')
+        mock_get_account.side_effect = TransportError('url', 500, 'Internal Server Error')
         before_time = datetime.datetime.now()
         try:
             tap_bing_ads.sync_accounts_stream(['i1'], {})
@@ -183,7 +182,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
         
     @mock.patch("tap_bing_ads.create_sdk_client", return_value = '')
@@ -228,7 +227,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
        
     @mock.patch("tap_bing_ads.create_sdk_client", return_value = '')
@@ -252,7 +251,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
         
     def test_connection_reset_error_sync_campaigns(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -272,7 +271,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
         
     def test_socket_timeout_error_sync_campaigns(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -292,7 +291,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
         
     def test_http_timeout_error_sync_campaigns(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -313,7 +312,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
         
     def test_internal_server_error_sync_campaigns(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -334,7 +333,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
         
     def test_transport_server_error_sync_campaigns(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -342,8 +341,7 @@ class TestBackoffError(unittest.TestCase):
                                                         mock_sobject_to_dict, mock_write_state, 
                                                         mock_write_bookmark, mock_metrics, mock_write_records, 
                                                         mock_filter_selected_fields_many):
-        with open('tests/base.py') as f:
-            mock_client = MockClient(TransportError('url', 500, 'Internal Server Error'))
+        mock_client = MockClient(TransportError('url', 500, 'Internal Server Error'))
         before_time = datetime.datetime.now()
         try:
             tap_bing_ads.sync_campaigns(mock_client, '', [])
@@ -352,7 +350,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
         
     def test_400_error_sync_campaigns(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -388,7 +386,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
 
     def test_ssl_eof_error_sync_campaigns(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -409,7 +407,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
     def test_connection_reset_error_sync_ad_groups(self, mock_get_selected_fields, mock_get_core_schema, 
                                                         mock_write_schema, mock_get_bookmark, 
@@ -428,7 +426,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
         
     def test_socket_timeout_error_sync_ad_groups(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -448,7 +446,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
         
     def test_http_timeout_error_sync_ad_groups(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -469,7 +467,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
         
     def test_internal_server_error_sync_ad_groups(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -490,7 +488,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
         
     def test_transport_error_sync_ad_groups(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -501,8 +499,7 @@ class TestBackoffError(unittest.TestCase):
         '''
         Test that tap retry for 60 seconds on the Transport error.
         '''
-        with open('tests/base.py') as f:
-            mock_client = MockClient(TransportError('url', 500, 'Internal Server Error'))
+        mock_client = MockClient(TransportError('url', 500, 'Internal Server Error'))
         before_time = datetime.datetime.now()
         try:
             tap_bing_ads.sync_ad_groups(mock_client, '', ['dummy_campaign_id'], [])
@@ -511,7 +508,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
         
     def test_400_error_sync_ad_groups(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -550,7 +547,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
  
     def test_ssl_eof_error_sync_ad_groups(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -571,7 +568,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)        
         
     def test_connection_reset_error_sync_ads(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -591,7 +588,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
         
     def test_socket_timeout_error_sync_ads(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -611,7 +608,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
         
     def test_http_timeout_error_sync_ads(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -632,7 +629,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
         
     def test_internal_server_error_sync_ads(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -653,7 +650,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)        
 
     def test_transport_error_sync_ads(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -664,8 +661,7 @@ class TestBackoffError(unittest.TestCase):
         '''
         Test that tap retry for 60 seconds on the Transport error.
         '''
-        with open('tests/base.py') as f:
-            mock_client = MockClient(TransportError('url', 500, 'Internal Server Error'))
+        mock_client = MockClient(TransportError('url', 500, 'Internal Server Error'))
         before_time = datetime.datetime.now()
         try:
             tap_bing_ads.sync_ads(mock_client, ['dummy_stream'], ['dummy_ad_id'])
@@ -674,7 +670,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60) 
 
     def test_400_error_sync_ads(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -713,7 +709,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60) 
 
     def test_ssl_eof_error_sync_ads(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -734,7 +730,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)  
         
     @mock.patch("tap_bing_ads.build_report_request")
@@ -757,7 +753,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
         
     @mock.patch("tap_bing_ads.build_report_request")
@@ -777,7 +773,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
         
     @mock.patch("tap_bing_ads.build_report_request")
@@ -801,7 +797,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
      
     @mock.patch("tap_bing_ads.build_report_request")   
@@ -825,7 +821,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
 
     @mock.patch("tap_bing_ads.build_report_request")   
@@ -838,8 +834,7 @@ class TestBackoffError(unittest.TestCase):
         '''
         Test that tap retry for 60 seconds on the Transport error.
         '''
-        with open('tests/base.py') as f:
-            mock_client = MockClient(TransportError('url', 500, 'Internal Server Error'))
+        mock_client = MockClient(TransportError('url', 500, 'Internal Server Error'))
         before_time = datetime.datetime.now()
         try:
             tap_bing_ads.get_report_request_id(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date', 'dummy_start_key',
@@ -849,7 +844,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
         
     @mock.patch("tap_bing_ads.build_report_request")   
@@ -894,7 +889,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
     
     @mock.patch("tap_bing_ads.build_report_request")   
@@ -918,7 +913,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
                 
     def test_connection_reset_error_build_report_request(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -938,7 +933,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
         
     def test_socket_timeout_error_build_report_request(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -958,7 +953,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
         
     def test_http_timeout_error_build_report_request(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -979,7 +974,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
      
     def test_internal_server_error_build_report_request(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -1000,7 +995,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
         
     def test_transport_error_build_report_request(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -1011,8 +1006,7 @@ class TestBackoffError(unittest.TestCase):
         '''
         Test that tap retry for 60 seconds on the Transport error.
         '''
-        with open('tests/base.py') as f:
-            mock_client = MockClient(TransportError('url', 500, 'Internal Server Error'))
+        mock_client = MockClient(TransportError('url', 500, 'Internal Server Error'))
         before_time = datetime.datetime.now()
         try:
             tap_bing_ads.build_report_request(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date')
@@ -1021,7 +1015,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
         
     def test_400_error_build_report_request(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -1059,7 +1053,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)   
     
     def test_ssl_eof_error_build_report_request(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -1080,7 +1074,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
                
     def test_connection_reset_error_get_report_schema(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -1100,7 +1094,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
         
     def test_socket_timeout_error_get_report_schema(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -1120,7 +1114,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
         
     def test_http_timeout_error_get_report_schema(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -1141,7 +1135,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
      
     def test_internal_server_error_get_report_schema(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -1162,7 +1156,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
 
     def test_transport_error_get_report_schema(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -1173,8 +1167,7 @@ class TestBackoffError(unittest.TestCase):
         '''
         Test that tap retry for 60 seconds on the Transport error.
         '''
-        with open('tests/base.py') as f:
-            mock_client = MockClient(TransportError('url', 500, 'Internal Server Error'))
+        mock_client = MockClient(TransportError('url', 500, 'Internal Server Error'))
         before_time = datetime.datetime.now()
         try:
             tap_bing_ads.get_report_schema(mock_client, '')
@@ -1183,7 +1176,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
 
     def test_400_error_get_report_schema(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -1222,7 +1215,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
     
     def test_ssl_eof_error_get_report_schema(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -1243,7 +1236,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
                 
     def test_connection_reset_error_get_type_map(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -1263,7 +1256,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
         
     def test_socket_timeout_error_get_type_map(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -1283,7 +1276,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
         
     def test_http_timeout_error_get_type_map(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -1304,7 +1297,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
      
     def test_internal_server_error_get_type_map(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -1325,7 +1318,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
 
     def test_transport_error_get_type_map(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -1336,8 +1329,7 @@ class TestBackoffError(unittest.TestCase):
         '''
         Test that tap retry for 60 seconds on the Transport error.
         '''
-        with open('tests/base.py') as f:
-            mock_client = MockClient(TransportError('url', 500, 'Internal Server Error'))
+        mock_client = MockClient(TransportError('url', 500, 'Internal Server Error'))
         before_time = datetime.datetime.now()
         try:
             tap_bing_ads.get_type_map(mock_client)
@@ -1346,7 +1338,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
         
     def test_400_error_get_type_map(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -1385,7 +1377,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
    
     def test_ssl_eof_error_get_type_map(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -1406,7 +1398,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
 
     async def test_connection_reset_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -1426,7 +1418,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
         
     async def test_socket_timeout_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -1446,7 +1438,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
         
     async def test_http_timeout_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -1467,7 +1459,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
      
     async def test_internal_server_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -1488,7 +1480,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
             
     async def test_transport_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -1499,8 +1491,7 @@ class TestBackoffError(unittest.TestCase):
         '''
         Test that tap retry for 60 seconds on the Transport error.
         '''
-        with open('tests/base.py') as f:
-            mock_client = MockClient(TransportError('url', 500, 'Internal Server Error'))
+        mock_client = MockClient(TransportError('url', 500, 'Internal Server Error'))
         before_time = datetime.datetime.now()
         try:
             await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
@@ -1509,7 +1500,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
         
     async def test_400_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -1548,7 +1539,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
 
     async def test_ssl_eof_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -1569,7 +1560,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
         
     @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
@@ -1592,7 +1583,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
         
     @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
@@ -1618,7 +1609,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
         
     @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
@@ -1645,7 +1636,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
         
     @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
@@ -1672,7 +1663,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
         
     @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
@@ -1689,8 +1680,7 @@ class TestBackoffError(unittest.TestCase):
         Test that tap retry for 60 seconds on the Transport error.
         '''
         mock_oauth.return_value = ''
-        with open('tests/base.py') as f:
-            mock_client.side_effect = TransportError('url', 500, 'Internal Server Error')
+        mock_client.side_effect = TransportError('url', 500, 'Internal Server Error')
         before_time = datetime.datetime.now()
         try:
             tap_bing_ads.create_sdk_client('dummy_service', {})
@@ -1699,7 +1689,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
         
     @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
@@ -1751,7 +1741,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
 
     @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
@@ -1778,5 +1768,5 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)

--- a/tests/unittests/test_backoff_error_handling.py
+++ b/tests/unittests/test_backoff_error_handling.py
@@ -1313,3 +1313,50 @@ class TestBackoffError(unittest.TestCase):
             pass
         # verify the code backed off and requested for 5 times
         self.assertEqual(mock_oauth.call_count, 5)
+        
+    
+    @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
+    @mock.patch("bingads.OAuthWebAuthCodeGrant.request_oauth_tokens_by_refresh_token")
+    @mock.patch("bingads.AuthorizationData", return_value = '')
+    @mock.patch("tap_bing_ads.CustomServiceClient")
+    def test_408_exception_error_create_sdk_client(self, mock_client, mock_authorization_data, mock_oauth, mock_config,
+                                                           mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap retry on the 408 Request Timeout Exception of 5 times.
+        '''
+        mock_oauth.return_value = ''
+        with open('tests/base.py') as f:
+            mock_client.side_effect = Exception((408, 'Request Timeout'))
+        try:
+            tap_bing_ads.create_sdk_client('dummy_service', {})
+        except Exception:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_oauth.call_count, 5)
+        
+    @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
+    @mock.patch("bingads.OAuthWebAuthCodeGrant.request_oauth_tokens_by_refresh_token")
+    @mock.patch("bingads.AuthorizationData", return_value = '')
+    @mock.patch("tap_bing_ads.CustomServiceClient")
+    def test_400_exception_error_create_sdk_client(self, mock_client, mock_authorization_data, mock_oauth, mock_config,
+                                                           mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap does not retry on the 400 Bad reques Exception.
+        '''
+        mock_oauth.return_value = ''
+        with open('tests/base.py') as f:
+            mock_client.side_effect = Exception((400, 'Bad request'))
+        try:
+            tap_bing_ads.create_sdk_client('dummy_service', {})
+        except Exception:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_oauth.call_count, 1)

--- a/tests/unittests/test_backoff_error_handling.py
+++ b/tests/unittests/test_backoff_error_handling.py
@@ -1,0 +1,1111 @@
+import unittest
+import socket
+from unittest import mock
+import tap_bing_ads
+import json
+from urllib.error import HTTPError
+import ssl
+from suds.transport import TransportError
+    
+class MockClient():
+    
+    def __init__(self, error):
+        self.error = error
+        self.count = 0
+        
+    def GetCampaignsByAccountId(self, AccountId, CampaignType):
+        self.count = self.count + 1
+        raise self.error
+    
+    def GetAdGroupsByCampaignId(self, CampaignId):
+        self.count = self.count + 1
+        raise self.error
+    
+    def GetAdsByAdGroupId(self, AdGroupId, AdTypes):
+        self.count = self.count + 1
+        raise self.error
+    
+    def PollGenerateReport(self):
+        self.count = self.count + 1
+        raise self.error
+    
+    def SubmitGenerateReport(self, report_request):
+        self.count = self.count + 1
+        raise self.error
+    
+    def PollGenerateReport(self, request_id):
+        self.count = self.count + 1
+        raise self.error
+    
+    @property
+    def factory(self):
+        self.count = self.count + 1
+        raise self.error
+    
+    @property 
+    def soap_client(self):
+        self.count = self.count + 1
+        raise self.error
+    
+    @property
+    def call_count(self):
+        return self.count
+
+@mock.patch("time.sleep")
+@mock.patch("tap_bing_ads.filter_selected_fields_many", return_value = '')
+@mock.patch("singer.write_records", return_value = '')
+@mock.patch("singer.metrics", return_value = '')
+@mock.patch("singer.write_bookmark", return_value = '')
+@mock.patch("singer.write_state", return_value = '')
+@mock.patch("tap_bing_ads.sobject_to_dict", return_value = '')
+@mock.patch("singer.get_bookmark", return_value = {'b1': 'b1'})
+@mock.patch("singer.write_schema", return_value = '')
+@mock.patch("tap_bing_ads.get_core_schema", return_value = '')
+@mock.patch("tap_bing_ads.get_selected_fields", return_value = '')
+class TestConnectionResetError(unittest.TestCase):
+    
+    @mock.patch("tap_bing_ads.create_sdk_client", return_value = '')
+    @mock.patch("tap_bing_ads.CustomServiceClient")
+    def test_connection_reset_error_get_account(self, mock_get_account, mock_create_sdk_client, 
+                                                    mock_get_selected_fields, mock_get_core_schema, 
+                                                    mock_write_schema, mock_get_bookmark, 
+                                                    mock_sobject_to_dict, mock_write_state, 
+                                                    mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                    mock_filter_selected_fields_many,mock_sleep):
+        mock_get_account.side_effect = socket.error(104, 'Connection reset by peer')
+        try:
+            tap_bing_ads.sync_accounts_stream(['i1'], {})
+        except ConnectionResetError:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_get_account.call_count, 5)
+        
+    @mock.patch("tap_bing_ads.create_sdk_client", return_value = '')
+    @mock.patch("tap_bing_ads.CustomServiceClient")
+    def test_socket_timeout__error_get_account(self, mock_get_account, mock_create_sdk_client, 
+                                                    mock_get_selected_fields, mock_get_core_schema, 
+                                                    mock_write_schema, mock_get_bookmark, 
+                                                    mock_sobject_to_dict, mock_write_state, 
+                                                    mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                    mock_filter_selected_fields_many,mock_sleep):
+        mock_get_account.side_effect = socket.timeout()
+        try:
+            tap_bing_ads.sync_accounts_stream(['i1'], {})
+        except socket.timeout:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_get_account.call_count, 5)
+        
+    @mock.patch("tap_bing_ads.create_sdk_client", return_value = '')
+    @mock.patch("tap_bing_ads.CustomServiceClient")
+    def test_http_timeout__error_get_account(self, mock_get_account, mock_create_sdk_client, 
+                                                    mock_get_selected_fields, mock_get_core_schema, 
+                                                    mock_write_schema, mock_get_bookmark, 
+                                                    mock_sobject_to_dict, mock_write_state, 
+                                                    mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                    mock_filter_selected_fields_many,mock_sleep):
+        with open('tests/base.py') as f:
+            mock_get_account.side_effect = HTTPError('url', 408, 'Request Timeout', {}, f)
+        try:
+            tap_bing_ads.sync_accounts_stream(['i1'], {})
+        except HTTPError:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_get_account.call_count, 5)
+        
+    @mock.patch("tap_bing_ads.create_sdk_client", return_value = '')
+    @mock.patch("tap_bing_ads.CustomServiceClient")
+    def test_internal_server_error_get_account(self, mock_get_account, mock_create_sdk_client, 
+                                                    mock_get_selected_fields, mock_get_core_schema, 
+                                                    mock_write_schema, mock_get_bookmark, 
+                                                    mock_sobject_to_dict, mock_write_state, 
+                                                    mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                    mock_filter_selected_fields_many,mock_sleep):
+        with open('tests/base.py') as f:
+            mock_get_account.side_effect = HTTPError('url', 500, 'Internal Server Error', {}, f)
+        try:
+            tap_bing_ads.sync_accounts_stream(['i1'], {})
+        except HTTPError:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_get_account.call_count, 5)
+        
+    @mock.patch("tap_bing_ads.create_sdk_client", return_value = '')
+    @mock.patch("tap_bing_ads.CustomServiceClient")
+    def test_transport_error_get_account(self, mock_get_account, mock_create_sdk_client, 
+                                                
+                                                           mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many,mock_sleep):
+        with open('tests/base.py') as f:
+            mock_get_account.side_effect = TransportError('url', 500, 'Internal Server Error')
+        try:
+            tap_bing_ads.sync_accounts_stream(['i1'], {})
+        except TransportError:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_get_account.call_count, 5)
+        
+    @mock.patch("tap_bing_ads.create_sdk_client", return_value = '')
+    @mock.patch("tap_bing_ads.CustomServiceClient")
+    def test_400_error_get_account(self, mock_get_account, mock_create_sdk_client, 
+                                        mock_get_selected_fields, mock_get_core_schema, 
+                                        mock_write_schema, mock_get_bookmark, 
+                                        mock_sobject_to_dict, mock_write_state, 
+                                        mock_write_bookmark, mock_metrics, mock_write_records, 
+                                        mock_filter_selected_fields_many,mock_sleep):
+        with open('tests/base.py') as f:
+            mock_get_account.side_effect = HTTPError('url', 400, 'Bad Request', {}, f)
+        try:
+            tap_bing_ads.sync_accounts_stream(['i1'], {})
+        except HTTPError:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_get_account.call_count, 1)
+        
+       
+    @mock.patch("tap_bing_ads.create_sdk_client", return_value = '')
+    @mock.patch("tap_bing_ads.CustomServiceClient")
+    def test_ssl_eof_error_get_account(self, mock_get_account, mock_create_sdk_client,
+                                                           mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many,mock_sleep):
+        with open('tests/base.py') as f:
+            mock_get_account.side_effect = ssl.SSLEOFError('EOF occurred in violation of protocol')
+        try:
+            tap_bing_ads.sync_accounts_stream(['i1'], {})
+        except ssl.SSLEOFError:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_get_account.call_count, 5)
+        
+    def test_connection_reset_error_sync_campaigns(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                        mock_write_schema, mock_get_bookmark, 
+                                                        mock_sobject_to_dict, mock_write_state, 
+                                                        mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                        mock_filter_selected_fields_many,mock_sleep):
+        mock_client = MockClient(socket.error(104, 'Connection reset by peer'))
+        try:
+            tap_bing_ads.sync_campaigns(mock_client, '', [])
+        except ConnectionResetError:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_client.call_count, 5)
+        
+    def test_socket_timeout_error_sync_campaigns(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                        mock_write_schema, mock_get_bookmark, 
+                                                        mock_sobject_to_dict, mock_write_state, 
+                                                        mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                        mock_filter_selected_fields_many,mock_sleep):
+        mock_client = MockClient(socket.timeout())
+        try:
+            tap_bing_ads.sync_campaigns(mock_client, '', [])
+        except socket.timeout:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_client.call_count, 5)
+        
+    def test_http_timeout_error_sync_campaigns(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                    mock_write_schema, mock_get_bookmark, 
+                                                    mock_sobject_to_dict, mock_write_state, 
+                                                    mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                    mock_filter_selected_fields_many,mock_sleep):
+        with open('tests/base.py') as f:
+            mock_client = MockClient(HTTPError('url', 408, 'Request Timeout', {}, f))
+        try:
+            tap_bing_ads.sync_campaigns(mock_client, '', [])
+        except HTTPError:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_client.call_count, 5)
+        
+    def test_internal_server_error_sync_campaigns(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                        mock_write_schema, mock_get_bookmark, 
+                                                        mock_sobject_to_dict, mock_write_state, 
+                                                        mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                        mock_filter_selected_fields_many,mock_sleep):
+        with open('tests/base.py') as f:
+            mock_client = MockClient(HTTPError('url', 500, 'Internal Server Error', {}, f))
+        try:
+            tap_bing_ads.sync_campaigns(mock_client, '', [])
+        except HTTPError:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_client.call_count, 5)
+        
+    def test_transport_server_error_sync_campaigns(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                        mock_write_schema, mock_get_bookmark, 
+                                                        mock_sobject_to_dict, mock_write_state, 
+                                                        mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                        mock_filter_selected_fields_many,mock_sleep):
+        with open('tests/base.py') as f:
+            mock_client = MockClient(TransportError('url', 500, 'Internal Server Error'))
+        try:
+            tap_bing_ads.sync_campaigns(mock_client, '', [])
+        except TransportError:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_client.call_count, 5)
+        
+    def test_400_error_sync_campaigns(self, mock_get_selected_fields, mock_get_core_schema, 
+                                            mock_write_schema, mock_get_bookmark, 
+                                            mock_sobject_to_dict, mock_write_state, 
+                                            mock_write_bookmark, mock_metrics, mock_write_records, 
+                                            mock_filter_selected_fields_many,mock_sleep):
+        with open('tests/base.py') as f:
+            mock_client = MockClient(HTTPError('url', 400, 'Bad Request', {}, f))
+        try:
+            tap_bing_ads.sync_campaigns(mock_client, '', [])
+        except HTTPError:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_client.call_count, 1)
+        
+    def test_ssl_eof_error_sync_campaigns(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                mock_write_schema, mock_get_bookmark, 
+                                                mock_sobject_to_dict, mock_write_state, 
+                                                mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                mock_filter_selected_fields_many,mock_sleep):
+        with open('tests/base.py') as f:
+            mock_client = MockClient(ssl.SSLEOFError('EOF occurred in violation of protocol'))
+        try:
+            tap_bing_ads.sync_campaigns(mock_client, '', [])
+        except ssl.SSLEOFError:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_client.call_count, 5)
+    def test_connection_reset_error_sync_ad_groups(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                        mock_write_schema, mock_get_bookmark, 
+                                                        mock_sobject_to_dict, mock_write_state, 
+                                                        mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                        mock_filter_selected_fields_many,mock_sleep):
+        mock_client = MockClient(socket.error(104, 'Connection reset by peer'))
+        try:
+            tap_bing_ads.sync_ad_groups(mock_client, '', ['dummy_campaign_id'], [])
+        except ConnectionResetError:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_client.call_count, 5)
+        
+    def test_socket_timeout_error_sync_ad_groups(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                        mock_write_schema, mock_get_bookmark, 
+                                                        mock_sobject_to_dict, mock_write_state, 
+                                                        mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                        mock_filter_selected_fields_many,mock_sleep):
+        mock_client = MockClient(socket.timeout())
+        try:
+            tap_bing_ads.sync_ad_groups(mock_client, '', ['dummy_campaign_id'], [])
+        except socket.timeout:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_client.call_count, 5)
+        
+    def test_http_timeout_error_sync_ad_groups(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                    mock_write_schema, mock_get_bookmark, 
+                                                    mock_sobject_to_dict, mock_write_state, 
+                                                    mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                    mock_filter_selected_fields_many,mock_sleep):
+        with open('tests/base.py') as f:
+            mock_client = MockClient(HTTPError('url', 408, 'Request Timeout', {}, f))
+        try:
+            tap_bing_ads.sync_ad_groups(mock_client, '', ['dummy_campaign_id'], [])
+        except HTTPError:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_client.call_count, 5)
+        
+    def test_internal_server_error_sync_ad_groups(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                        mock_write_schema, mock_get_bookmark, 
+                                                        mock_sobject_to_dict, mock_write_state, 
+                                                        mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                        mock_filter_selected_fields_many,mock_sleep):
+        with open('tests/base.py') as f:
+            mock_client = MockClient(HTTPError('url', 500, 'Internal Server Error', {}, f))
+        try:
+            tap_bing_ads.sync_ad_groups(mock_client, '', ['dummy_campaign_id'], [])
+        except HTTPError:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_client.call_count, 5)
+        
+    def test_transport_error_sync_ad_groups(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                        mock_write_schema, mock_get_bookmark, 
+                                                        mock_sobject_to_dict, mock_write_state, 
+                                                        mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                        mock_filter_selected_fields_many,mock_sleep):
+        with open('tests/base.py') as f:
+            mock_client = MockClient(TransportError('url', 500, 'Internal Server Error'))
+        try:
+            tap_bing_ads.sync_ad_groups(mock_client, '', ['dummy_campaign_id'], [])
+        except TransportError:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_client.call_count, 5)
+        
+    def test_400_error_sync_ad_groups(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                        mock_write_schema, mock_get_bookmark, 
+                                                        mock_sobject_to_dict, mock_write_state, 
+                                                        mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                        mock_filter_selected_fields_many,mock_sleep):
+        with open('tests/base.py') as f:
+            mock_client = MockClient(HTTPError('url', 400, 'Bad Request', {}, f))
+        try:
+            tap_bing_ads.sync_ad_groups(mock_client, '', ['dummy_campaign_id'], [])
+        except HTTPError:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_client.call_count, 1)
+        
+    def test_ssl_eof_error_sync_ad_groups(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                mock_write_schema, mock_get_bookmark, 
+                                                mock_sobject_to_dict, mock_write_state, 
+                                                mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                mock_filter_selected_fields_many,mock_sleep):
+        with open('tests/base.py') as f:
+            mock_client = MockClient(ssl.SSLEOFError('EOF occurred in violation of protocol'))
+        try:
+            tap_bing_ads.sync_ad_groups(mock_client, '', ['dummy_campaign_id'], [])
+        except ssl.SSLEOFError:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_client.call_count, 5)        
+        
+    def test_connection_reset_error_sync_ads(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                mock_write_schema, mock_get_bookmark, 
+                                                mock_sobject_to_dict, mock_write_state, 
+                                                mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                mock_filter_selected_fields_many,mock_sleep):
+        mock_client = MockClient(socket.error(104, 'Connection reset by peer'))
+        try:
+            tap_bing_ads.sync_ads(mock_client, ['dummy_stream'], ['dummy_ad_id'])
+        except ConnectionResetError:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_client.call_count, 5)
+        
+    def test_socket_timeout_error_sync_ads(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                mock_write_schema, mock_get_bookmark, 
+                                                mock_sobject_to_dict, mock_write_state, 
+                                                mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                mock_filter_selected_fields_many,mock_sleep):
+        mock_client = MockClient(socket.timeout())
+        try:
+            tap_bing_ads.sync_ads(mock_client, ['dummy_stream'], ['dummy_ad_id'])
+        except socket.timeout:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_client.call_count, 5)
+        
+    def test_http_timeout_error_sync_ads(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                mock_write_schema, mock_get_bookmark, 
+                                                mock_sobject_to_dict, mock_write_state, 
+                                                mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                smock_filter_selected_fields_many,mock_sleep):
+        with open('tests/base.py') as f:
+            mock_client = MockClient(HTTPError('url', 408, 'Request Timeout', {}, f))
+        try:
+            tap_bing_ads.sync_ads(mock_client, ['dummy_stream'], ['dummy_ad_id'])
+        except HTTPError:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_client.call_count, 5)
+        
+    def test_internal_server_error_sync_ads(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                mock_write_schema, mock_get_bookmark, 
+                                                mock_sobject_to_dict, mock_write_state, 
+                                                mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                mock_filter_selected_fields_many,mock_sleep):
+        with open('tests/base.py') as f:
+            mock_client = MockClient(HTTPError('url', 500, 'Internal Server Error', {}, f))
+        try:
+            tap_bing_ads.sync_ads(mock_client, ['dummy_stream'], ['dummy_ad_id'])
+        except HTTPError:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_client.call_count, 5)        
+
+    def test_transport_error_sync_ads(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                mock_write_schema, mock_get_bookmark, 
+                                                mock_sobject_to_dict, mock_write_state, 
+                                                mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                mock_filter_selected_fields_many,mock_sleep):
+        with open('tests/base.py') as f:
+            mock_client = MockClient(TransportError('url', 500, 'Internal Server Error'))
+        try:
+            tap_bing_ads.sync_ads(mock_client, ['dummy_stream'], ['dummy_ad_id'])
+        except TransportError:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_client.call_count, 5) 
+
+    def test_400_error_sync_ads(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                mock_write_schema, mock_get_bookmark, 
+                                                mock_sobject_to_dict, mock_write_state, 
+                                                mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                mock_filter_selected_fields_many,mock_sleep):
+        with open('tests/base.py') as f:
+            mock_client = MockClient(HTTPError('url', 400, 'Bad Request', {}, f))
+        try:
+            tap_bing_ads.sync_ads(mock_client, ['dummy_stream'], ['dummy_ad_id'])
+        except HTTPError:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_client.call_count, 1) 
+        
+    def test_ssl_eof_error_sync_ads(self, mock_get_selected_fields, mock_get_core_schema, 
+                                        mock_write_schema, mock_get_bookmark, 
+                                        mock_sobject_to_dict, mock_write_state, 
+                                        mock_write_bookmark, mock_metrics, mock_write_records, 
+                                        mock_filter_selected_fields_many,mock_sleep):
+        with open('tests/base.py') as f:
+            mock_client = MockClient(ssl.SSLEOFError('EOF occurred in violation of protocol'))
+        try:
+            tap_bing_ads.sync_ads(mock_client, ['dummy_stream'], ['dummy_ad_id'])
+        except ssl.SSLEOFError:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_client.call_count, 5)  
+        
+    @mock.patch("tap_bing_ads.build_report_request")
+    def test_connection_reset_error_get_report_request_id(self, mock_build_report_request, 
+                                                           mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many,mock_sleep):
+        mock_client = MockClient(socket.error(104, 'Connection reset by peer'))
+        try:
+            tap_bing_ads.get_report_request_id(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date', 'dummy_start_key',
+                                                force_refresh = True)
+        except ConnectionResetError:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_client.call_count, 5)
+        
+    @mock.patch("tap_bing_ads.build_report_request")
+    def test_socket_timeout_error_get_report_request_id(self, mock_build_report_request, 
+                                                           mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many,mock_sleep):
+        mock_client = MockClient(socket.timeout())
+        try:
+           tap_bing_ads.get_report_request_id(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date', 'dummy_start_key', 
+                                              force_refresh = True)
+        except socket.timeout:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_client.call_count, 5)
+        
+    @mock.patch("tap_bing_ads.build_report_request")
+    def test_http_timeout_error_get_report_request_id(self, mock_build_report_request, 
+                                                           mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many,mock_sleep):
+        with open('tests/base.py') as f:
+            mock_client = MockClient(HTTPError('url', 408, 'Request Timeout', {}, f))
+        try:
+            tap_bing_ads.get_report_request_id(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date', 'dummy_start_key',
+                                               force_refresh = True)
+        except HTTPError:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_client.call_count, 5)
+     
+    @mock.patch("tap_bing_ads.build_report_request")   
+    def test_internal_server_error_get_report_request_id(self, mock_build_report_request,
+                                                           mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many,mock_sleep):
+        with open('tests/base.py') as f:
+            mock_client = MockClient(HTTPError('url', 500, 'Internal Server Error', {}, f))
+        try:
+            tap_bing_ads.get_report_request_id(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date', 'dummy_start_key',
+                                               force_refresh = True)
+        except HTTPError:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_client.call_count, 5)
+
+    @mock.patch("tap_bing_ads.build_report_request")   
+    def test_transport_error_get_report_request_id(self, mock_build_report_request,
+                                                           mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many,mock_sleep):
+        with open('tests/base.py') as f:
+            mock_client = MockClient(TransportError('url', 500, 'Internal Server Error'))
+        try:
+            tap_bing_ads.get_report_request_id(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date', 'dummy_start_key',
+                                               force_refresh = True)
+        except TransportError:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_client.call_count, 5)
+        
+    @mock.patch("tap_bing_ads.build_report_request")   
+    def test_400_error_get_report_request_id(self, mock_build_report_request,
+                                                           mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many,mock_sleep):
+        with open('tests/base.py') as f:
+            mock_client = MockClient(HTTPError('url', 400, 'Bad Request', {}, f))
+        try:
+            tap_bing_ads.get_report_request_id(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date', 'dummy_start_key',
+                                               force_refresh = True)
+        except HTTPError:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_client.call_count, 1)
+        
+    @mock.patch("tap_bing_ads.build_report_request")   
+    def test_ssl_eof_error_get_report_request_id(self, mock_build_report_request,
+                                                           mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many,mock_sleep):
+        with open('tests/base.py') as f:
+            mock_client = MockClient(ssl.SSLEOFError('EOF occurred in violation of protocol'))
+        try:
+            tap_bing_ads.get_report_request_id(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date', 'dummy_start_key',
+                                               force_refresh = True)
+        except ssl.SSLEOFError:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_client.call_count, 5)
+                
+    def test_connection_reset_error_build_report_request(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many,mock_sleep):
+        mock_client = MockClient(socket.error(104, 'Connection reset by peer'))
+        try:
+            tap_bing_ads.build_report_request(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date')
+        except ConnectionResetError:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_client.call_count, 5)
+        
+    def test_socket_timeout_error_build_report_request(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many,mock_sleep):
+        mock_client = MockClient(socket.timeout())
+        try:
+           tap_bing_ads.build_report_request(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date')
+        except socket.timeout:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_client.call_count, 5)
+        
+    def test_http_timeout_error_build_report_request(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many,mock_sleep):
+        with open('tests/base.py') as f:
+            mock_client = MockClient(HTTPError('url', 408, 'Request Timeout', {}, f))
+        try:
+            tap_bing_ads.build_report_request(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date')
+        except HTTPError:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_client.call_count, 5)
+     
+    def test_internal_server_error_build_report_request(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many,mock_sleep):
+        with open('tests/base.py') as f:
+            mock_client = MockClient(HTTPError('url', 500, 'Internal Server Error', {}, f))
+        try:
+            tap_bing_ads.build_report_request(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date')
+        except HTTPError:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_client.call_count, 5)
+        
+    def test_transport_error_build_report_request(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many,mock_sleep):
+        with open('tests/base.py') as f:
+            mock_client = MockClient(TransportError('url', 500, 'Internal Server Error'))
+        try:
+            tap_bing_ads.build_report_request(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date')
+        except TransportError:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_client.call_count, 5)
+        
+    def test_400_error_build_report_request(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many,mock_sleep):
+        with open('tests/base.py') as f:
+            mock_client = MockClient(HTTPError('url', 400, 'Bad Request', {}, f))
+        try:
+            tap_bing_ads.build_report_request(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date')
+        except HTTPError:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_client.call_count, 1)
+        
+    def test_ssl_eof_error_build_report_request(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                    mock_write_schema, mock_get_bookmark, 
+                                                    mock_sobject_to_dict, mock_write_state, 
+                                                    mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                    mock_filter_selected_fields_many,mock_sleep):
+        with open('tests/base.py') as f:
+            mock_client = MockClient(ssl.SSLEOFError('EOF occurred in violation of protocol'))
+        try:
+            tap_bing_ads.build_report_request(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date')
+        except ssl.SSLEOFError:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_client.call_count, 5)
+               
+    def test_connection_reset_error_get_report_schema(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many,mock_sleep):
+        mock_client = MockClient(socket.error(104, 'Connection reset by peer'))
+        try:
+            tap_bing_ads.get_report_schema(mock_client, '')
+        except ConnectionResetError:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_client.call_count, 5)
+        
+    def test_socket_timeout_error_get_report_schema(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many,mock_sleep):
+        mock_client = MockClient(socket.timeout())
+        try:
+           tap_bing_ads.get_report_schema(mock_client, '')
+        except socket.timeout:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_client.call_count, 5)
+        
+    def test_http_timeout_error_get_report_schema(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                        mock_write_schema, mock_get_bookmark, 
+                                                        mock_sobject_to_dict, mock_write_state, 
+                                                        mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                        mock_filter_selected_fields_many,mock_sleep):
+        with open('tests/base.py') as f:
+            mock_client = MockClient(HTTPError('url', 408, 'Request Timeout', {}, f))
+        try:
+            tap_bing_ads.get_report_schema(mock_client, '')
+        except HTTPError:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_client.call_count, 5)
+     
+    def test_internal_server_error_get_report_schema(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many,mock_sleep):
+        with open('tests/base.py') as f:
+            mock_client = MockClient(HTTPError('url', 500, 'Internal Server Error', {}, f))
+        try:
+            tap_bing_ads.get_report_schema(mock_client, '')
+        except HTTPError:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_client.call_count, 5)
+
+    def test_transport_error_get_report_schema(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many,mock_sleep):
+        with open('tests/base.py') as f:
+            mock_client = MockClient(TransportError('url', 500, 'Internal Server Error'))
+        try:
+            tap_bing_ads.get_report_schema(mock_client, '')
+        except TransportError:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_client.call_count, 5)
+
+    def test_400_error_get_report_schema(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many,mock_sleep):
+        with open('tests/base.py') as f:
+            mock_client = MockClient(HTTPError('url', 400, 'Bad Request', {}, f))
+        try:
+            tap_bing_ads.get_report_schema(mock_client, '')
+        except HTTPError:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_client.call_count, 1)
+         
+    def test_ssl_eof_error_get_report_schema(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                mock_write_schema, mock_get_bookmark, 
+                                                mock_sobject_to_dict, mock_write_state, 
+                                                mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                mock_filter_selected_fields_many,mock_sleep):
+        with open('tests/base.py') as f:
+            mock_client = MockClient(ssl.SSLEOFError('EOF occurred in violation of protocol'))
+        try:
+            tap_bing_ads.get_report_schema(mock_client, '')
+        except ssl.SSLEOFError:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_client.call_count, 5)
+                
+    def test_connection_reset_error_get_type_map(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                    mock_write_schema, mock_get_bookmark, 
+                                                    mock_sobject_to_dict, mock_write_state, 
+                                                    mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                    mock_filter_selected_fields_many,mock_sleep):
+        mock_client = MockClient(socket.error(104, 'Connection reset by peer'))
+        try:
+            tap_bing_ads.get_type_map(mock_client)
+        except ConnectionResetError:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_client.call_count, 5)
+        
+    def test_socket_timeout_error_get_type_map(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                    mock_write_schema, mock_get_bookmark, 
+                                                    mock_sobject_to_dict, mock_write_state, 
+                                                    mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                    mock_filter_selected_fields_many,mock_sleep):
+        mock_client = MockClient(socket.timeout())
+        try:
+           tap_bing_ads.get_type_map(mock_client)
+        except socket.timeout:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_client.call_count, 5)
+        
+    def test_http_timeout_error_get_type_map(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                mock_write_schema, mock_get_bookmark, 
+                                                mock_sobject_to_dict, mock_write_state, 
+                                                mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                mock_filter_selected_fields_many,mock_sleep):
+        with open('tests/base.py') as f:
+            mock_client = MockClient(HTTPError('url', 408, 'Request Timeout', {}, f))
+        try:
+            tap_bing_ads.get_type_map(mock_client)
+        except HTTPError:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_client.call_count, 5)
+     
+    def test_internal_server_error_get_type_map(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                    mock_write_schema, mock_get_bookmark, 
+                                                    mock_sobject_to_dict, mock_write_state, 
+                                                    mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                    mock_filter_selected_fields_many,mock_sleep):
+        with open('tests/base.py') as f:
+            mock_client = MockClient(HTTPError('url', 500, 'Internal Server Error', {}, f))
+        try:
+            tap_bing_ads.get_type_map(mock_client)
+        except HTTPError:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_client.call_count, 5)
+
+    def test_transport_error_get_type_map(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                    mock_write_schema, mock_get_bookmark, 
+                                                    mock_sobject_to_dict, mock_write_state, 
+                                                    mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                    mock_filter_selected_fields_many,mock_sleep):
+        with open('tests/base.py') as f:
+            mock_client = MockClient(TransportError('url', 500, 'Internal Server Error'))
+        try:
+            tap_bing_ads.get_type_map(mock_client)
+        except TransportError:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_client.call_count, 5)
+        
+    def test_400_error_get_type_map(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                    mock_write_schema, mock_get_bookmark, 
+                                                    mock_sobject_to_dict, mock_write_state, 
+                                                    mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                    mock_filter_selected_fields_many,mock_sleep):
+        with open('tests/base.py') as f:
+            mock_client = MockClient(HTTPError('url', 400, 'Bad Request', {}, f))
+        try:
+            tap_bing_ads.get_type_map(mock_client)
+        except HTTPError:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_client.call_count, 1)
+        
+    def test_ssl_eof_error_get_type_map(self, mock_get_selected_fields, mock_get_core_schema, 
+                                            mock_write_schema, mock_get_bookmark, 
+                                            mock_sobject_to_dict, mock_write_state, 
+                                            mock_write_bookmark, mock_metrics, mock_write_records, 
+                                            mock_filter_selected_fields_many,mock_sleep):
+        with open('tests/base.py') as f:
+            mock_client = MockClient(ssl.SSLEOFError('EOF occurred in violation of protocol'))
+        try:
+            tap_bing_ads.get_type_map(mock_client)
+        except ssl.SSLEOFError:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_client.call_count, 5)
+
+    async def test_connection_reset_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many,mock_sleep):
+        mock_client = MockClient(socket.error(104, 'Connection reset by peer'))
+        try:
+            await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
+        except ConnectionResetError:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_client.call_count, 5)
+        
+    async def test_socket_timeout_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many,mock_sleep):
+        mock_client = MockClient(socket.timeout())
+        try:
+           await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
+        except socket.timeout:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_client.call_count, 5)
+        
+    async def test_http_timeout_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                        mock_write_schema, mock_get_bookmark, 
+                                                        mock_sobject_to_dict, mock_write_state, 
+                                                        mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                        mock_filter_selected_fields_many,mock_sleep):
+        with open('tests/base.py') as f:
+            mock_client = MockClient(HTTPError('url', 408, 'Request Timeout', {}, f))
+        try:
+            await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
+        except HTTPError:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_client.call_count, 5)
+     
+    async def test_internal_server_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many,mock_sleep):
+        with open('tests/base.py') as f:
+            mock_client = MockClient(HTTPError('url', 500, 'Internal Server Error', {}, f))
+        try:
+            await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
+        except HTTPError:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_client.call_count, 5)
+            
+    async def test_transport_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many,mock_sleep):
+        with open('tests/base.py') as f:
+            mock_client = MockClient(TransportError('url', 500, 'Internal Server Error'))
+        try:
+            await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
+        except TransportError:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_client.call_count, 5)
+        
+    async def test_400_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many,mock_sleep):
+        with open('tests/base.py') as f:
+            mock_client = MockClient(HTTPError('url', 400, 'Bad Request', {}, f))
+        try:
+            await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
+        except HTTPError:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_client.call_count, 1)
+        
+    async def test_ssl_eof_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                    mock_write_schema, mock_get_bookmark, 
+                                                    mock_sobject_to_dict, mock_write_state, 
+                                                    mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                    mock_filter_selected_fields_many,mock_sleep):
+        with open('tests/base.py') as f:
+            mock_client = MockClient(ssl.SSLEOFError('EOF occurred in violation of protocol'))
+        try:
+            s = await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
+        except ssl.SSLEOFError:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_client.call_count, 5)
+        
+    @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
+    @mock.patch("bingads.OAuthWebAuthCodeGrant.request_oauth_tokens_by_refresh_token")
+    @mock.patch("bingads.AuthorizationData", return_value = '')
+    @mock.patch("tap_bing_ads.CustomServiceClient")
+    def test_connection_reset_create_sdk_client(self, mock_client, mock_authorization_data, mock_oauth, mock_config,
+                                                        mock_get_selected_fields, mock_get_core_schema, 
+                                                        mock_write_schema, mock_get_bookmark, 
+                                                        mock_sobject_to_dict, mock_write_state, 
+                                                        mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                        mock_filter_selected_fields_many,mock_sleep):
+        mock_oauth.return_value = ''
+        mock_client.side_effect = socket.error(104, 'Connection reset by peer')
+        try:
+            tap_bing_ads.create_sdk_client('dummy_service', {})
+        except ConnectionResetError:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_oauth.call_count, 5)
+        
+    @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
+    @mock.patch("bingads.OAuthWebAuthCodeGrant.request_oauth_tokens_by_refresh_token")
+    @mock.patch("bingads.AuthorizationData", return_value = '')
+    @mock.patch("tap_bing_ads.CustomServiceClient")
+    def test_socket_timeout_create_sdk_client(self, mock_client, mock_authorization_data, mock_oauth, mock_config,
+                                                    mock_get_selected_fields, mock_get_core_schema, 
+                                                    mock_write_schema, mock_get_bookmark, 
+                                                    mock_sobject_to_dict, mock_write_state, 
+                                                    mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                    mock_filter_selected_fields_many,mock_sleep):
+        mock_oauth.return_value = ''
+        mock_client.side_effect = socket.timeout()
+        try:
+            tap_bing_ads.create_sdk_client('dummy_service', {})
+        except socket.timeout:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_oauth.call_count, 5)
+        
+    @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
+    @mock.patch("bingads.OAuthWebAuthCodeGrant.request_oauth_tokens_by_refresh_token")
+    @mock.patch("bingads.AuthorizationData", return_value = '')
+    @mock.patch("tap_bing_ads.CustomServiceClient")
+    def test_http_timeout_error_create_sdk_client(self, mock_client, mock_authorization_data, mock_oauth, mock_config, 
+                                                        mock_get_selected_fields, mock_get_core_schema, 
+                                                        mock_write_schema, mock_get_bookmark, 
+                                                        mock_sobject_to_dict, mock_write_state, 
+                                                        mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                        mock_filter_selected_fields_many,mock_sleep):
+        mock_oauth.return_value = ''
+        with open('tests/base.py') as f:
+            mock_client.side_effect = HTTPError('url', 408, 'Request Timeout', {}, f)
+        try:
+            tap_bing_ads.create_sdk_client('dummy_service', {})
+        except HTTPError:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_oauth.call_count, 5)
+        
+    @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
+    @mock.patch("bingads.OAuthWebAuthCodeGrant.request_oauth_tokens_by_refresh_token")
+    @mock.patch("bingads.AuthorizationData", return_value = '')
+    @mock.patch("tap_bing_ads.CustomServiceClient")
+    def test_internal_server_error_create_sdk_client(self, mock_client, mock_authorization_data, mock_oauth, mock_config,
+                                                           mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many,mock_sleep):
+        mock_oauth.return_value = ''
+        with open('tests/base.py') as f:
+            mock_client.side_effect = HTTPError('url', 500, 'Internal Server Error', {}, f)
+        try:
+            tap_bing_ads.create_sdk_client('dummy_service', {})
+        except HTTPError:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_oauth.call_count, 5)
+        
+    @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
+    @mock.patch("bingads.OAuthWebAuthCodeGrant.request_oauth_tokens_by_refresh_token")
+    @mock.patch("bingads.AuthorizationData", return_value = '')
+    @mock.patch("tap_bing_ads.CustomServiceClient")
+    def test_transport_error_create_sdk_client(self, mock_client, mock_authorization_data, mock_oauth, mock_config,
+                                                    mock_get_selected_fields, mock_get_core_schema, 
+                                                    mock_write_schema, mock_get_bookmark, 
+                                                    mock_sobject_to_dict, mock_write_state, 
+                                                    mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                    mock_filter_selected_fields_many,mock_sleep):
+        mock_oauth.return_value = ''
+        with open('tests/base.py') as f:
+            mock_client.side_effect = TransportError('url', 500, 'Internal Server Error')
+        try:
+            tap_bing_ads.create_sdk_client('dummy_service', {})
+        except TransportError:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_oauth.call_count, 5)
+        
+    @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
+    @mock.patch("bingads.OAuthWebAuthCodeGrant.request_oauth_tokens_by_refresh_token")
+    @mock.patch("bingads.AuthorizationData", return_value = '')
+    @mock.patch("tap_bing_ads.CustomServiceClient")
+    def test_400_error_create_sdk_client(self, mock_client, mock_authorization_data, mock_oauth, mock_config,
+                                                mock_get_selected_fields, mock_get_core_schema, 
+                                                mock_write_schema, mock_get_bookmark, 
+                                                mock_sobject_to_dict, mock_write_state, 
+                                                mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                mock_filter_selected_fields_many,mock_sleep):
+        mock_oauth.return_value = ''
+        with open('tests/base.py') as f:
+            mock_client.side_effect = HTTPError('url', 400, 'Bad Request', {}, f)
+        try:
+            tap_bing_ads.create_sdk_client('dummy_service', {})
+        except HTTPError:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_oauth.call_count, 1)
+        
+        
+    @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
+    @mock.patch("bingads.OAuthWebAuthCodeGrant.request_oauth_tokens_by_refresh_token")
+    @mock.patch("bingads.AuthorizationData", return_value = '')
+    @mock.patch("tap_bing_ads.CustomServiceClient")
+    def test_ssl_eof_error_create_sdk_client(self, mock_client, mock_authorization_data, mock_oauth, mock_config,
+                                                           mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many,mock_sleep):
+        mock_oauth.return_value = ''
+        with open('tests/base.py') as f:
+            mock_client.side_effect = ssl.SSLEOFError('EOF occurred in violation of protocol')
+        try:
+            tap_bing_ads.create_sdk_client('dummy_service', {})
+        except ssl.SSLEOFError:
+            pass
+        # verify the code backed off and requested for 5 times
+        self.assertEqual(mock_oauth.call_count, 5)

--- a/tests/unittests/test_backoff_error_handling.py
+++ b/tests/unittests/test_backoff_error_handling.py
@@ -74,13 +74,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.sync_accounts_stream(['i1'], {})
         except ConnectionResetError:
-            pass
-        
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
         
     @mock.patch("tap_bing_ads.create_sdk_client", return_value = '')
     @mock.patch("tap_bing_ads.CustomServiceClient")
@@ -98,12 +96,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.sync_accounts_stream(['i1'], {})
         except socket.timeout:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
         
     @mock.patch("tap_bing_ads.create_sdk_client", return_value = '')
     @mock.patch("tap_bing_ads.CustomServiceClient")
@@ -122,12 +119,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.sync_accounts_stream(['i1'], {})
         except HTTPError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
         
     @mock.patch("tap_bing_ads.create_sdk_client", return_value = '')
     @mock.patch("tap_bing_ads.CustomServiceClient")
@@ -146,12 +142,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.sync_accounts_stream(['i1'], {})
         except HTTPError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
         
     @mock.patch("tap_bing_ads.create_sdk_client", return_value = '')
     @mock.patch("tap_bing_ads.CustomServiceClient")
@@ -169,12 +164,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.sync_accounts_stream(['i1'], {})
         except TransportError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
         
     @mock.patch("tap_bing_ads.create_sdk_client", return_value = '')
     @mock.patch("tap_bing_ads.CustomServiceClient")
@@ -193,13 +187,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.sync_accounts_stream(['i1'], {})
         except HTTPError:
-            pass
-        
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code raise error without backoff
-        # time_difference should be less or equal 1 as it directly raise the error without backoff
-        self.assertGreaterEqual(1, time_difference)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code raise error without backoff
+            # time_difference should be less or equal 1 as it directly raise the error without backoff
+            self.assertGreaterEqual(1, time_difference)
 
     @mock.patch("tap_bing_ads.create_sdk_client", return_value = '')
     @mock.patch("tap_bing_ads.CustomServiceClient")
@@ -218,12 +210,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.sync_accounts_stream(['i1'], {})
         except URLError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
        
     @mock.patch("tap_bing_ads.create_sdk_client", return_value = '')
     @mock.patch("tap_bing_ads.CustomServiceClient")
@@ -242,12 +233,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.sync_accounts_stream(['i1'], {})
         except ssl.SSLEOFError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
 
     @mock.patch("tap_bing_ads.create_sdk_client", return_value = '')
     @mock.patch("tap_bing_ads.CustomServiceClient")
@@ -266,12 +256,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.sync_accounts_stream(['i1'], {})
         except Exception:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
         
     def test_connection_reset_error_sync_campaigns(self, mock_get_selected_fields, mock_get_core_schema, 
                                                         mock_write_schema, mock_get_bookmark, 
@@ -286,12 +275,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.sync_campaigns(mock_client, '', [])
         except ConnectionResetError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
         
     def test_socket_timeout_error_sync_campaigns(self, mock_get_selected_fields, mock_get_core_schema, 
                                                         mock_write_schema, mock_get_bookmark, 
@@ -306,12 +294,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.sync_campaigns(mock_client, '', [])
         except socket.timeout:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
         
     def test_http_timeout_error_sync_campaigns(self, mock_get_selected_fields, mock_get_core_schema, 
                                                     mock_write_schema, mock_get_bookmark, 
@@ -327,12 +314,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.sync_campaigns(mock_client, '', [])
         except HTTPError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
         
     def test_internal_server_error_sync_campaigns(self, mock_get_selected_fields, mock_get_core_schema, 
                                                         mock_write_schema, mock_get_bookmark, 
@@ -348,12 +334,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.sync_campaigns(mock_client, '', [])
         except HTTPError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
         
     def test_transport_server_error_sync_campaigns(self, mock_get_selected_fields, mock_get_core_schema, 
                                                         mock_write_schema, mock_get_bookmark, 
@@ -365,12 +350,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.sync_campaigns(mock_client, '', [])
         except TransportError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
         
     def test_400_error_sync_campaigns(self, mock_get_selected_fields, mock_get_core_schema, 
                                             mock_write_schema, mock_get_bookmark, 
@@ -386,12 +370,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.sync_campaigns(mock_client, '', [])
         except HTTPError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code raise error without backoff
-        # time_difference should be less or equal 1 as it directly raise the error without backoff
-        self.assertGreaterEqual(1, time_difference)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code raise error without backoff
+            # time_difference should be less or equal 1 as it directly raise the error without backoff
+            self.assertGreaterEqual(1, time_difference)
     
     def test_url_error_sync_campaigns(self, mock_get_selected_fields, mock_get_core_schema, 
                                                         mock_write_schema, mock_get_bookmark, 
@@ -404,12 +387,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.sync_campaigns(mock_client, '', [])
         except URLError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
 
     def test_ssl_eof_error_sync_campaigns(self, mock_get_selected_fields, mock_get_core_schema, 
                                                 mock_write_schema, mock_get_bookmark, 
@@ -425,12 +407,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.sync_campaigns(mock_client, '', [])
         except ssl.SSLEOFError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
 
     def test_exception_408_sync_campaigns(self, mock_get_selected_fields, mock_get_core_schema, 
                                                         mock_write_schema, mock_get_bookmark, 
@@ -443,12 +424,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.sync_campaigns(mock_client, '', [])
         except Exception:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
 
     def test_connection_reset_error_sync_ad_groups(self, mock_get_selected_fields, mock_get_core_schema, 
                                                         mock_write_schema, mock_get_bookmark, 
@@ -463,12 +443,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.sync_ad_groups(mock_client, '', ['dummy_campaign_id'], [])
         except ConnectionResetError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
         
     def test_socket_timeout_error_sync_ad_groups(self, mock_get_selected_fields, mock_get_core_schema, 
                                                         mock_write_schema, mock_get_bookmark, 
@@ -483,12 +462,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.sync_ad_groups(mock_client, '', ['dummy_campaign_id'], [])
         except socket.timeout:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
         
     def test_http_timeout_error_sync_ad_groups(self, mock_get_selected_fields, mock_get_core_schema, 
                                                     mock_write_schema, mock_get_bookmark, 
@@ -504,12 +482,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.sync_ad_groups(mock_client, '', ['dummy_campaign_id'], [])
         except HTTPError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
         
     def test_internal_server_error_sync_ad_groups(self, mock_get_selected_fields, mock_get_core_schema, 
                                                         mock_write_schema, mock_get_bookmark, 
@@ -525,12 +502,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.sync_ad_groups(mock_client, '', ['dummy_campaign_id'], [])
         except HTTPError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
         
     def test_transport_error_sync_ad_groups(self, mock_get_selected_fields, mock_get_core_schema, 
                                                         mock_write_schema, mock_get_bookmark, 
@@ -545,12 +521,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.sync_ad_groups(mock_client, '', ['dummy_campaign_id'], [])
         except TransportError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
         
     def test_400_error_sync_ad_groups(self, mock_get_selected_fields, mock_get_core_schema, 
                                                         mock_write_schema, mock_get_bookmark, 
@@ -566,12 +541,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.sync_ad_groups(mock_client, '', ['dummy_campaign_id'], [])
         except HTTPError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code raise error without backoff
-        # time_difference should be less or equal 1 as it directly raise the error without backoff
-        self.assertGreaterEqual(1, time_difference)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code raise error without backoff
+            # time_difference should be less or equal 1 as it directly raise the error without backoff
+            self.assertGreaterEqual(1, time_difference)
 
     def test_url_error_sync_ad_groups(self, mock_get_selected_fields, mock_get_core_schema, 
                                                         mock_write_schema, mock_get_bookmark, 
@@ -587,12 +561,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.sync_ad_groups(mock_client, '', ['dummy_campaign_id'], [])
         except URLError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
  
     def test_ssl_eof_error_sync_ad_groups(self, mock_get_selected_fields, mock_get_core_schema, 
                                                 mock_write_schema, mock_get_bookmark, 
@@ -608,12 +581,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.sync_ad_groups(mock_client, '', ['dummy_campaign_id'], [])
         except ssl.SSLEOFError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)        
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)        
 
     def test_exception_408_sync_ad_groups(self, mock_get_selected_fields, mock_get_core_schema, 
                                                         mock_write_schema, mock_get_bookmark, 
@@ -629,12 +601,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.sync_ad_groups(mock_client, '', ['dummy_campaign_id'], [])
         except Exception:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
 
     def test_connection_reset_error_sync_ads(self, mock_get_selected_fields, mock_get_core_schema, 
                                                 mock_write_schema, mock_get_bookmark, 
@@ -649,12 +620,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.sync_ads(mock_client, ['dummy_stream'], ['dummy_ad_id'])
         except ConnectionResetError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
         
     def test_socket_timeout_error_sync_ads(self, mock_get_selected_fields, mock_get_core_schema, 
                                                 mock_write_schema, mock_get_bookmark, 
@@ -669,12 +639,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.sync_ads(mock_client, ['dummy_stream'], ['dummy_ad_id'])
         except socket.timeout:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
         
     def test_http_timeout_error_sync_ads(self, mock_get_selected_fields, mock_get_core_schema, 
                                                 mock_write_schema, mock_get_bookmark, 
@@ -690,12 +659,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.sync_ads(mock_client, ['dummy_stream'], ['dummy_ad_id'])
         except HTTPError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
         
     def test_internal_server_error_sync_ads(self, mock_get_selected_fields, mock_get_core_schema, 
                                                 mock_write_schema, mock_get_bookmark, 
@@ -711,12 +679,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.sync_ads(mock_client, ['dummy_stream'], ['dummy_ad_id'])
         except HTTPError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)        
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)        
 
     def test_transport_error_sync_ads(self, mock_get_selected_fields, mock_get_core_schema, 
                                                 mock_write_schema, mock_get_bookmark, 
@@ -731,12 +698,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.sync_ads(mock_client, ['dummy_stream'], ['dummy_ad_id'])
         except TransportError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60) 
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60) 
 
     def test_400_error_sync_ads(self, mock_get_selected_fields, mock_get_core_schema, 
                                                 mock_write_schema, mock_get_bookmark, 
@@ -752,12 +718,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.sync_ads(mock_client, ['dummy_stream'], ['dummy_ad_id'])
         except HTTPError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code raise error without backoff
-        # time_difference should be less or equal 1 as it directly raise the error without backoff
-        self.assertGreaterEqual(1, time_difference)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code raise error without backoff
+            # time_difference should be less or equal 1 as it directly raise the error without backoff
+            self.assertGreaterEqual(1, time_difference)
 
     def test_url_error_sync_ads(self, mock_get_selected_fields, mock_get_core_schema, 
                                                 mock_write_schema, mock_get_bookmark, 
@@ -773,12 +738,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.sync_ads(mock_client, ['dummy_stream'], ['dummy_ad_id'])
         except URLError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60) 
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60) 
 
     def test_ssl_eof_error_sync_ads(self, mock_get_selected_fields, mock_get_core_schema, 
                                         mock_write_schema, mock_get_bookmark, 
@@ -794,12 +758,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.sync_ads(mock_client, ['dummy_stream'], ['dummy_ad_id'])
         except ssl.SSLEOFError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)  
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)  
 
     def test_exception_408_sync_ads(self, mock_get_selected_fields, mock_get_core_schema, 
                                                 mock_write_schema, mock_get_bookmark, 
@@ -815,12 +778,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.sync_ads(mock_client, ['dummy_stream'], ['dummy_ad_id'])
         except Exception:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60) 
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60) 
 
     @mock.patch("tap_bing_ads.build_report_request")
     def test_connection_reset_error_get_report_request_id(self, mock_build_report_request, 
@@ -838,12 +800,11 @@ class TestBackoffError(unittest.TestCase):
             tap_bing_ads.get_report_request_id(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date', 'dummy_start_key',
                                                 force_refresh = True)
         except ConnectionResetError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
         
     @mock.patch("tap_bing_ads.build_report_request")
     def test_socket_timeout_error_get_report_request_id(self, mock_build_report_request, 
@@ -858,12 +819,11 @@ class TestBackoffError(unittest.TestCase):
            tap_bing_ads.get_report_request_id(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date', 'dummy_start_key', 
                                               force_refresh = True)
         except socket.timeout:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
         
     @mock.patch("tap_bing_ads.build_report_request")
     def test_http_timeout_error_get_report_request_id(self, mock_build_report_request, 
@@ -882,12 +842,11 @@ class TestBackoffError(unittest.TestCase):
             tap_bing_ads.get_report_request_id(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date', 'dummy_start_key',
                                                force_refresh = True)
         except HTTPError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
      
     @mock.patch("tap_bing_ads.build_report_request")   
     def test_internal_server_error_get_report_request_id(self, mock_build_report_request,
@@ -906,12 +865,11 @@ class TestBackoffError(unittest.TestCase):
             tap_bing_ads.get_report_request_id(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date', 'dummy_start_key',
                                                force_refresh = True)
         except HTTPError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
 
     @mock.patch("tap_bing_ads.build_report_request")   
     def test_transport_error_get_report_request_id(self, mock_build_report_request,
@@ -929,12 +887,11 @@ class TestBackoffError(unittest.TestCase):
             tap_bing_ads.get_report_request_id(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date', 'dummy_start_key',
                                                force_refresh = True)
         except TransportError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
         
     @mock.patch("tap_bing_ads.build_report_request")   
     def test_400_error_get_report_request_id(self, mock_build_report_request,
@@ -953,12 +910,11 @@ class TestBackoffError(unittest.TestCase):
             tap_bing_ads.get_report_request_id(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date', 'dummy_start_key',
                                                force_refresh = True)
         except HTTPError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code raise error without backoff
-        # time_difference should be less or equal 1 as it directly raise the error without backoff
-        self.assertGreaterEqual(1, time_difference)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code raise error without backoff
+            # time_difference should be less or equal 1 as it directly raise the error without backoff
+            self.assertGreaterEqual(1, time_difference)
 
     @mock.patch("tap_bing_ads.build_report_request")   
     def test_url_error_get_report_request_id(self, mock_build_report_request,
@@ -977,12 +933,11 @@ class TestBackoffError(unittest.TestCase):
             tap_bing_ads.get_report_request_id(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date', 'dummy_start_key',
                                                force_refresh = True)
         except URLError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
     
     @mock.patch("tap_bing_ads.build_report_request")   
     def test_ssl_eof_error_get_report_request_id(self, mock_build_report_request,
@@ -1001,12 +956,11 @@ class TestBackoffError(unittest.TestCase):
             tap_bing_ads.get_report_request_id(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date', 'dummy_start_key',
                                                force_refresh = True)
         except ssl.SSLEOFError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
 
     @mock.patch("tap_bing_ads.build_report_request")   
     def test_url_error_get_report_request_id(self, mock_build_report_request,
@@ -1025,12 +979,11 @@ class TestBackoffError(unittest.TestCase):
             tap_bing_ads.get_report_request_id(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date', 'dummy_start_key',
                                                force_refresh = True)
         except Exception:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
 
     def test_connection_reset_error_build_report_request(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
@@ -1045,12 +998,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.build_report_request(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date')
         except ConnectionResetError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
         
     def test_socket_timeout_error_build_report_request(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
@@ -1065,12 +1017,11 @@ class TestBackoffError(unittest.TestCase):
         try:
            tap_bing_ads.build_report_request(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date')
         except socket.timeout:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
         
     def test_http_timeout_error_build_report_request(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
@@ -1086,12 +1037,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.build_report_request(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date')
         except HTTPError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
      
     def test_internal_server_error_build_report_request(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
@@ -1107,12 +1057,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.build_report_request(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date')
         except HTTPError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
         
     def test_transport_error_build_report_request(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
@@ -1127,12 +1076,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.build_report_request(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date')
         except TransportError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
         
     def test_400_error_build_report_request(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
@@ -1148,12 +1096,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.build_report_request(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date')
         except HTTPError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code raise error without backoff
-        # time_difference should be less or equal 1 as it directly raise the error without backoff
-        self.assertGreaterEqual(1, time_difference)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code raise error without backoff
+            # time_difference should be less or equal 1 as it directly raise the error without backoff
+            self.assertGreaterEqual(1, time_difference)
 
     def test_url_error_build_report_request(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
@@ -1168,12 +1115,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.build_report_request(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date')
         except URLError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)   
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)   
     
     def test_ssl_eof_error_build_report_request(self, mock_get_selected_fields, mock_get_core_schema, 
                                                     mock_write_schema, mock_get_bookmark, 
@@ -1189,12 +1135,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.build_report_request(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date')
         except ssl.SSLEOFError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
 
     def test_408_exception_build_report_request(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
@@ -1209,12 +1154,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.build_report_request(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date')
         except Exception:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)  
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)  
 
     def test_connection_reset_error_get_report_schema(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
@@ -1229,12 +1173,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.get_report_schema(mock_client, '')
         except ConnectionResetError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
         
     def test_socket_timeout_error_get_report_schema(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
@@ -1249,12 +1192,11 @@ class TestBackoffError(unittest.TestCase):
         try:
            tap_bing_ads.get_report_schema(mock_client, '')
         except socket.timeout:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
         
     def test_http_timeout_error_get_report_schema(self, mock_get_selected_fields, mock_get_core_schema, 
                                                         mock_write_schema, mock_get_bookmark, 
@@ -1270,12 +1212,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.get_report_schema(mock_client, '')
         except HTTPError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
      
     def test_internal_server_error_get_report_schema(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
@@ -1291,12 +1232,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.get_report_schema(mock_client, '')
         except HTTPError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
 
     def test_transport_error_get_report_schema(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
@@ -1311,12 +1251,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.get_report_schema(mock_client, '')
         except TransportError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
 
     def test_400_error_get_report_schema(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
@@ -1332,12 +1271,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.get_report_schema(mock_client, '')
         except HTTPError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code raise error without backoff
-        # time_difference should be less or equal 1 as it directly raise the error without backoff
-        self.assertGreaterEqual(1, time_difference)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code raise error without backoff
+            # time_difference should be less or equal 1 as it directly raise the error without backoff
+            self.assertGreaterEqual(1, time_difference)
 
     def test_url_error_get_report_schema(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
@@ -1353,12 +1291,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.get_report_schema(mock_client, '')
         except URLError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
     
     def test_ssl_eof_error_get_report_schema(self, mock_get_selected_fields, mock_get_core_schema, 
                                                 mock_write_schema, mock_get_bookmark, 
@@ -1374,12 +1311,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.get_report_schema(mock_client, '')
         except ssl.SSLEOFError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
     
     def test_exception_408_get_report_schema(self, mock_get_selected_fields, mock_get_core_schema, 
                                                 mock_write_schema, mock_get_bookmark, 
@@ -1395,12 +1331,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.get_report_schema(mock_client, '')
         except Exception:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
 
                 
     def test_connection_reset_error_get_type_map(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -1416,12 +1351,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.get_type_map(mock_client)
         except ConnectionResetError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
         
     def test_socket_timeout_error_get_type_map(self, mock_get_selected_fields, mock_get_core_schema, 
                                                     mock_write_schema, mock_get_bookmark, 
@@ -1436,12 +1370,11 @@ class TestBackoffError(unittest.TestCase):
         try:
            tap_bing_ads.get_type_map(mock_client)
         except socket.timeout:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
         
     def test_http_timeout_error_get_type_map(self, mock_get_selected_fields, mock_get_core_schema, 
                                                 mock_write_schema, mock_get_bookmark, 
@@ -1457,12 +1390,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.get_type_map(mock_client)
         except HTTPError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
      
     def test_internal_server_error_get_type_map(self, mock_get_selected_fields, mock_get_core_schema, 
                                                     mock_write_schema, mock_get_bookmark, 
@@ -1478,12 +1410,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.get_type_map(mock_client)
         except HTTPError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
 
     def test_transport_error_get_type_map(self, mock_get_selected_fields, mock_get_core_schema, 
                                                     mock_write_schema, mock_get_bookmark, 
@@ -1498,12 +1429,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.get_type_map(mock_client)
         except TransportError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
         
     def test_400_error_get_type_map(self, mock_get_selected_fields, mock_get_core_schema, 
                                                     mock_write_schema, mock_get_bookmark, 
@@ -1519,12 +1449,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.get_type_map(mock_client)
         except HTTPError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code raise error without backoff
-        # time_difference should be less or equal 1 as it directly raise the error without backoff
-        self.assertGreaterEqual(1, time_difference)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code raise error without backoff
+            # time_difference should be less or equal 1 as it directly raise the error without backoff
+            self.assertGreaterEqual(1, time_difference)
 
     def test_url_error_get_type_map(self, mock_get_selected_fields, mock_get_core_schema, 
                                                     mock_write_schema, mock_get_bookmark, 
@@ -1540,12 +1469,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.get_type_map(mock_client)
         except URLError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
    
     def test_ssl_eof_error_get_type_map(self, mock_get_selected_fields, mock_get_core_schema, 
                                             mock_write_schema, mock_get_bookmark, 
@@ -1561,12 +1489,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.get_type_map(mock_client)
         except ssl.SSLEOFError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
 
     def test_exception_408_get_type_map(self, mock_get_selected_fields, mock_get_core_schema, 
                                                     mock_write_schema, mock_get_bookmark, 
@@ -1581,12 +1508,11 @@ class TestBackoffError(unittest.TestCase):
         try:
            tap_bing_ads.get_type_map(mock_client)
         except Exception:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
 
     async def test_connection_reset_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
@@ -1601,12 +1527,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
         except ConnectionResetError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
         
     async def test_socket_timeout_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
@@ -1621,12 +1546,11 @@ class TestBackoffError(unittest.TestCase):
         try:
            await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
         except socket.timeout:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
         
     async def test_http_timeout_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
                                                         mock_write_schema, mock_get_bookmark, 
@@ -1642,12 +1566,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
         except HTTPError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
      
     async def test_internal_server_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
@@ -1663,12 +1586,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
         except HTTPError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
             
     async def test_transport_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
@@ -1683,12 +1605,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
         except TransportError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
         
     async def test_400_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
@@ -1704,12 +1625,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
         except HTTPError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code raise error without backoff
-        # time_difference should be less or equal 1 as it directly raise the error without backoff
-        self.assertGreaterEqual(1, time_difference)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code raise error without backoff
+            # time_difference should be less or equal 1 as it directly raise the error without backoff
+            self.assertGreaterEqual(1, time_difference)
 
     async def test_url_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
@@ -1725,12 +1645,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
         except URLError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
 
     async def test_ssl_eof_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
                                                     mock_write_schema, mock_get_bookmark, 
@@ -1746,12 +1665,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             s = await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
         except ssl.SSLEOFError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
 
     async def test_exception_408_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
@@ -1767,12 +1685,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
         except Exception:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
 
     @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
     @mock.patch("bingads.OAuthWebAuthCodeGrant.request_oauth_tokens_by_refresh_token")
@@ -1790,12 +1707,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.create_sdk_client('dummy_service', {})
         except ConnectionResetError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
         
     @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
     @mock.patch("bingads.OAuthWebAuthCodeGrant.request_oauth_tokens_by_refresh_token")
@@ -1816,12 +1732,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.create_sdk_client('dummy_service', {})
         except socket.timeout:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
         
     @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
     @mock.patch("bingads.OAuthWebAuthCodeGrant.request_oauth_tokens_by_refresh_token")
@@ -1843,12 +1758,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.create_sdk_client('dummy_service', {})
         except HTTPError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
         
     @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
     @mock.patch("bingads.OAuthWebAuthCodeGrant.request_oauth_tokens_by_refresh_token")
@@ -1870,12 +1784,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.create_sdk_client('dummy_service', {})
         except HTTPError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
         
     @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
     @mock.patch("bingads.OAuthWebAuthCodeGrant.request_oauth_tokens_by_refresh_token")
@@ -1896,12 +1809,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.create_sdk_client('dummy_service', {})
         except TransportError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
         
     @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
     @mock.patch("bingads.OAuthWebAuthCodeGrant.request_oauth_tokens_by_refresh_token")
@@ -1923,12 +1835,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.create_sdk_client('dummy_service', {})
         except HTTPError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code raise error without backoff
-        # time_difference should be less or equal 1 as it directly raise the error without backoff
-        self.assertGreaterEqual(1, time_difference)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code raise error without backoff
+            # time_difference should be less or equal 1 as it directly raise the error without backoff
+            self.assertGreaterEqual(1, time_difference)
         
         
     @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
@@ -1951,12 +1862,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.create_sdk_client('dummy_service', {})
         except ssl.SSLEOFError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
 
     @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
     @mock.patch("bingads.OAuthWebAuthCodeGrant.request_oauth_tokens_by_refresh_token")
@@ -1978,12 +1888,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.create_sdk_client('dummy_service', {})
         except URLError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
 
     @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
     @mock.patch("bingads.OAuthWebAuthCodeGrant.request_oauth_tokens_by_refresh_token")
@@ -2004,10 +1913,9 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.create_sdk_client('dummy_service', {})
         except Exception:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
 

--- a/tests/unittests/test_backoff_error_handling.py
+++ b/tests/unittests/test_backoff_error_handling.py
@@ -25,10 +25,6 @@ class MockClient():
         self.count = self.count + 1
         raise self.error
 
-    def PollGenerateReport(self):
-        self.count = self.count + 1
-        raise self.error
-
     def SubmitGenerateReport(self, report_request):
         self.count = self.count + 1
         raise self.error
@@ -253,6 +249,30 @@ class TestBackoffError(unittest.TestCase):
         # verify the code backed off for 60 seconds
         # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
+
+    @mock.patch("tap_bing_ads.create_sdk_client", return_value = '')
+    @mock.patch("tap_bing_ads.CustomServiceClient")
+    def test_exception_408_error_get_account(self, mock_get_account, mock_create_sdk_client,
+                                                           mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the Exception with error code 408.
+        '''
+        mock_get_account.side_effect = Exception((408, 'Request Timeout'))
+
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.sync_accounts_stream(['i1'], {})
+        except Exception:
+            pass
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
         
     def test_connection_reset_error_sync_campaigns(self, mock_get_selected_fields, mock_get_core_schema, 
                                                         mock_write_schema, mock_get_bookmark, 
@@ -409,6 +429,25 @@ class TestBackoffError(unittest.TestCase):
         # verify the code backed off for 60 seconds
         # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
+
+    def test_exception_408_sync_campaigns(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                        mock_write_schema, mock_get_bookmark, 
+                                                        mock_sobject_to_dict, mock_write_state, 
+                                                        mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                        mock_filter_selected_fields_many):
+        mock_client = MockClient(Exception((408, 'Request Timeout')))
+        
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.sync_campaigns(mock_client, '', [])
+        except Exception:
+            pass
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
+
     def test_connection_reset_error_sync_ad_groups(self, mock_get_selected_fields, mock_get_core_schema, 
                                                         mock_write_schema, mock_get_bookmark, 
                                                         mock_sobject_to_dict, mock_write_state, 
@@ -570,7 +609,28 @@ class TestBackoffError(unittest.TestCase):
         # verify the code backed off for 60 seconds
         # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)        
+
+    def test_exception_408_sync_ad_groups(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                        mock_write_schema, mock_get_bookmark, 
+                                                        mock_sobject_to_dict, mock_write_state, 
+                                                        mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                        mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the Exception with error code 408.
+        '''
+        mock_client = MockClient(Exception((408, 'Request Timeout')))
         
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.sync_ad_groups(mock_client, '', ['dummy_campaign_id'], [])
+        except Exception:
+            pass
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
+
     def test_connection_reset_error_sync_ads(self, mock_get_selected_fields, mock_get_core_schema, 
                                                 mock_write_schema, mock_get_bookmark, 
                                                 mock_sobject_to_dict, mock_write_state, 
@@ -732,7 +792,28 @@ class TestBackoffError(unittest.TestCase):
         # verify the code backed off for 60 seconds
         # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)  
+
+    def test_exception_408_sync_ads(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                mock_write_schema, mock_get_bookmark, 
+                                                mock_sobject_to_dict, mock_write_state, 
+                                                mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the Exception with error code 408.
+        '''
+        mock_client = MockClient(Exception((408, 'Request Timeout')))
         
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.sync_ads(mock_client, ['dummy_stream'], ['dummy_ad_id'])
+        except Exception:
+            pass
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60) 
+
     @mock.patch("tap_bing_ads.build_report_request")
     def test_connection_reset_error_get_report_request_id(self, mock_build_report_request, 
                                                            mock_get_selected_fields, mock_get_core_schema, 
@@ -915,7 +996,31 @@ class TestBackoffError(unittest.TestCase):
         # verify the code backed off for 60 seconds
         # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
-                
+
+    @mock.patch("tap_bing_ads.build_report_request")   
+    def test_url_error_get_report_request_id(self, mock_build_report_request,
+                                                           mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the Exception with error code 408.
+        '''
+        mock_client = MockClient(Exception((408, 'Request Timeout')))
+        
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.get_report_request_id(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date', 'dummy_start_key',
+                                               force_refresh = True)
+        except Exception:
+            pass
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
+
     def test_connection_reset_error_build_report_request(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
@@ -1076,7 +1181,27 @@ class TestBackoffError(unittest.TestCase):
         # verify the code backed off for 60 seconds
         # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
-               
+
+    def test_408_exception_build_report_request(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the Exception with error code 408.
+        '''
+        mock_client = MockClient(Exception((408, 'Request Timeout')))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.build_report_request(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date')
+        except Exception:
+            pass
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)  
+
     def test_connection_reset_error_get_report_schema(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
@@ -1238,6 +1363,28 @@ class TestBackoffError(unittest.TestCase):
         # verify the code backed off for 60 seconds
         # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
+    
+    def test_exception_408_get_report_schema(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                mock_write_schema, mock_get_bookmark, 
+                                                mock_sobject_to_dict, mock_write_state, 
+                                                mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the Exception with error code 408.
+        '''
+        with open('tests/base.py') as f:
+            mock_client = MockClient(Exception((408, 'Request Timeout')))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.get_report_schema(mock_client, '')
+        except Exception:
+            pass
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
+
                 
     def test_connection_reset_error_get_type_map(self, mock_get_selected_fields, mock_get_core_schema, 
                                                     mock_write_schema, mock_get_bookmark, 
@@ -1394,6 +1541,26 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.get_type_map(mock_client)
         except ssl.SSLEOFError:
+            pass
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
+
+    def test_exception_408_get_type_map(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                    mock_write_schema, mock_get_bookmark, 
+                                                    mock_sobject_to_dict, mock_write_state, 
+                                                    mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                    mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the Exception with error code 408.
+        '''
+        mock_client = MockClient(Exception((408, 'Request Timeout')))
+        before_time = datetime.datetime.now()
+        try:
+           tap_bing_ads.get_type_map(mock_client)
+        except Exception:
             pass
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
@@ -1562,7 +1729,28 @@ class TestBackoffError(unittest.TestCase):
         # verify the code backed off for 60 seconds
         # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
+
+    async def test_exception_408_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the Exception with error code 408.
+        '''
+        mock_client = MockClient(Exception((408, 'Request Timeout')))
         
+        before_time = datetime.datetime.now()
+        try:
+            await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
+        except Exception:
+            pass
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
+
     @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
     @mock.patch("bingads.OAuthWebAuthCodeGrant.request_oauth_tokens_by_refresh_token")
     @mock.patch("bingads.AuthorizationData", return_value = '')
@@ -1770,3 +1958,30 @@ class TestBackoffError(unittest.TestCase):
         # verify the code backed off for 60 seconds
         # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
+
+    @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
+    @mock.patch("bingads.OAuthWebAuthCodeGrant.request_oauth_tokens_by_refresh_token")
+    @mock.patch("bingads.AuthorizationData", return_value = '')
+    @mock.patch("tap_bing_ads.CustomServiceClient")
+    def test_exception_408_error_create_sdk_client(self, mock_client, mock_authorization_data, mock_oauth, mock_config,
+                                                    mock_get_selected_fields, mock_get_core_schema, 
+                                                    mock_write_schema, mock_get_bookmark, 
+                                                    mock_sobject_to_dict, mock_write_state, 
+                                                    mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                    mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the Exception with error code 408.
+        '''
+        mock_oauth.return_value = ''
+        mock_client.side_effect = Exception((408, 'Request Timeout'))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.create_sdk_client('dummy_service', {})
+        except Exception:
+            pass
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
+

--- a/tests/unittests/test_backoff_error_handling.py
+++ b/tests/unittests/test_backoff_error_handling.py
@@ -194,8 +194,12 @@ class TestBackoffError(unittest.TestCase):
             tap_bing_ads.sync_accounts_stream(['i1'], {})
         except HTTPError:
             pass
+        
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
         # verify the code raise error without backoff
-        self.assertEqual(mock_get_account.call_count, 1)
+        # time_difference should be less or equal 1 as it directly raise the error without backoff
+        self.assertGreaterEqual(1, time_difference)
 
     @mock.patch("tap_bing_ads.create_sdk_client", return_value = '')
     @mock.patch("tap_bing_ads.CustomServiceClient")
@@ -383,8 +387,11 @@ class TestBackoffError(unittest.TestCase):
             tap_bing_ads.sync_campaigns(mock_client, '', [])
         except HTTPError:
             pass
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
         # verify the code raise error without backoff
-        self.assertEqual(mock_client.call_count, 1)
+        # time_difference should be less or equal 1 as it directly raise the error without backoff
+        self.assertGreaterEqual(1, time_difference)
     
     def test_url_error_sync_campaigns(self, mock_get_selected_fields, mock_get_core_schema, 
                                                         mock_write_schema, mock_get_bookmark, 
@@ -560,8 +567,11 @@ class TestBackoffError(unittest.TestCase):
             tap_bing_ads.sync_ad_groups(mock_client, '', ['dummy_campaign_id'], [])
         except HTTPError:
             pass
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
         # verify the code raise error without backoff
-        self.assertEqual(mock_client.call_count, 1)
+        # time_difference should be less or equal 1 as it directly raise the error without backoff
+        self.assertGreaterEqual(1, time_difference)
 
     def test_url_error_sync_ad_groups(self, mock_get_selected_fields, mock_get_core_schema, 
                                                         mock_write_schema, mock_get_bookmark, 
@@ -743,8 +753,11 @@ class TestBackoffError(unittest.TestCase):
             tap_bing_ads.sync_ads(mock_client, ['dummy_stream'], ['dummy_ad_id'])
         except HTTPError:
             pass
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
         # verify the code raise error without backoff
-        self.assertEqual(mock_client.call_count, 1) 
+        # time_difference should be less or equal 1 as it directly raise the error without backoff
+        self.assertGreaterEqual(1, time_difference)
 
     def test_url_error_sync_ads(self, mock_get_selected_fields, mock_get_core_schema, 
                                                 mock_write_schema, mock_get_bookmark, 
@@ -941,8 +954,11 @@ class TestBackoffError(unittest.TestCase):
                                                force_refresh = True)
         except HTTPError:
             pass
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
         # verify the code raise error without backoff
-        self.assertEqual(mock_client.call_count, 1)
+        # time_difference should be less or equal 1 as it directly raise the error without backoff
+        self.assertGreaterEqual(1, time_difference)
 
     @mock.patch("tap_bing_ads.build_report_request")   
     def test_url_error_get_report_request_id(self, mock_build_report_request,
@@ -1133,8 +1149,11 @@ class TestBackoffError(unittest.TestCase):
             tap_bing_ads.build_report_request(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date')
         except HTTPError:
             pass
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
         # verify the code raise error without backoff
-        self.assertEqual(mock_client.call_count, 1)
+        # time_difference should be less or equal 1 as it directly raise the error without backoff
+        self.assertGreaterEqual(1, time_difference)
 
     def test_url_error_build_report_request(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
@@ -1314,8 +1333,11 @@ class TestBackoffError(unittest.TestCase):
             tap_bing_ads.get_report_schema(mock_client, '')
         except HTTPError:
             pass
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
         # verify the code raise error without backoff
-        self.assertEqual(mock_client.call_count, 1)
+        # time_difference should be less or equal 1 as it directly raise the error without backoff
+        self.assertGreaterEqual(1, time_difference)
 
     def test_url_error_get_report_schema(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
@@ -1498,8 +1520,11 @@ class TestBackoffError(unittest.TestCase):
             tap_bing_ads.get_type_map(mock_client)
         except HTTPError:
             pass
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
         # verify the code raise error without backoff
-        self.assertEqual(mock_client.call_count, 1)
+        # time_difference should be less or equal 1 as it directly raise the error without backoff
+        self.assertGreaterEqual(1, time_difference)
 
     def test_url_error_get_type_map(self, mock_get_selected_fields, mock_get_core_schema, 
                                                     mock_write_schema, mock_get_bookmark, 
@@ -1680,8 +1705,11 @@ class TestBackoffError(unittest.TestCase):
             await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
         except HTTPError:
             pass
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
         # verify the code raise error without backoff
-        self.assertEqual(mock_client.call_count, 1)
+        # time_difference should be less or equal 1 as it directly raise the error without backoff
+        self.assertGreaterEqual(1, time_difference)
 
     async def test_url_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
@@ -1896,8 +1924,10 @@ class TestBackoffError(unittest.TestCase):
             tap_bing_ads.create_sdk_client('dummy_service', {})
         except HTTPError:
             pass
+        time_difference = (after_time - before_time).total_seconds()
         # verify the code raise error without backoff
-        self.assertEqual(mock_oauth.call_count, 1)
+        # time_difference should be less or equal 1 as it directly raise the error without backoff
+        self.assertGreaterEqual(1, time_difference)
         
         
     @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            

--- a/tests/unittests/test_backoff_error_handling.py
+++ b/tests/unittests/test_backoff_error_handling.py
@@ -2,7 +2,6 @@ import unittest
 import socket
 from unittest import mock
 import tap_bing_ads
-import json
 from urllib.error import HTTPError
 import ssl
 from suds.transport import TransportError
@@ -1564,55 +1563,3 @@ class TestBackoffError(unittest.TestCase):
         # verify the code backed off for 60 seconds
         # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
-        
-    
-    @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
-    @mock.patch("bingads.OAuthWebAuthCodeGrant.request_oauth_tokens_by_refresh_token")
-    @mock.patch("bingads.AuthorizationData", return_value = '')
-    @mock.patch("tap_bing_ads.CustomServiceClient")
-    def test_408_exception_error_create_sdk_client(self, mock_client, mock_authorization_data, mock_oauth, mock_config,
-                                                           mock_get_selected_fields, mock_get_core_schema, 
-                                                           mock_write_schema, mock_get_bookmark, 
-                                                           mock_sobject_to_dict, mock_write_state, 
-                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many):
-        '''
-        Test that tap retry for 60 seconds on the 408 Request Timeout Exception of.
-        '''
-        mock_oauth.return_value = ''
-        with open('tests/base.py') as f:
-            mock_client.side_effect = Exception((408, 'Request Timeout'))
-        before_time = datetime.datetime.now()
-        try:
-            tap_bing_ads.create_sdk_client('dummy_service', {})
-        except Exception:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
-        
-    @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
-    @mock.patch("bingads.OAuthWebAuthCodeGrant.request_oauth_tokens_by_refresh_token")
-    @mock.patch("bingads.AuthorizationData", return_value = '')
-    @mock.patch("tap_bing_ads.CustomServiceClient")
-    def test_400_exception_error_create_sdk_client(self, mock_client, mock_authorization_data, mock_oauth, mock_config,
-                                                           mock_get_selected_fields, mock_get_core_schema, 
-                                                           mock_write_schema, mock_get_bookmark, 
-                                                           mock_sobject_to_dict, mock_write_state, 
-                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many):
-        '''
-        Test that tap does not retry on the 400 Bad reques Exception.
-        '''
-        mock_oauth.return_value = ''
-        with open('tests/base.py') as f:
-            mock_client.side_effect = Exception((400, 'Bad request'))
-        before_time = datetime.datetime.now()
-        try:
-            tap_bing_ads.create_sdk_client('dummy_service', {})
-        except Exception:
-            pass
-        # verify the code backed off and requested for
-        self.assertEqual(mock_oauth.call_count, 1)

--- a/tests/unittests/test_backoff_error_handling.py
+++ b/tests/unittests/test_backoff_error_handling.py
@@ -8,45 +8,45 @@ import ssl
 from suds.transport import TransportError
     
 class MockClient():
-    
+    '''Mocked ServiceClient class and it's method to pass the test case'''
     def __init__(self, error):
         self.error = error
         self.count = 0
-        
+
     def GetCampaignsByAccountId(self, AccountId, CampaignType):
         self.count = self.count + 1
         raise self.error
-    
+
     def GetAdGroupsByCampaignId(self, CampaignId):
         self.count = self.count + 1
         raise self.error
-    
+
     def GetAdsByAdGroupId(self, AdGroupId, AdTypes):
         self.count = self.count + 1
         raise self.error
-    
+
     def PollGenerateReport(self):
         self.count = self.count + 1
         raise self.error
-    
+
     def SubmitGenerateReport(self, report_request):
         self.count = self.count + 1
         raise self.error
-    
+
     def PollGenerateReport(self, request_id):
         self.count = self.count + 1
         raise self.error
-    
+
     @property
     def factory(self):
         self.count = self.count + 1
         raise self.error
-    
-    @property 
+
+    @property
     def soap_client(self):
         self.count = self.count + 1
         raise self.error
-    
+
     @property
     def call_count(self):
         return self.count
@@ -62,16 +62,23 @@ class MockClient():
 @mock.patch("singer.write_schema", return_value = '')
 @mock.patch("tap_bing_ads.get_core_schema", return_value = '')
 @mock.patch("tap_bing_ads.get_selected_fields", return_value = '')
-class TestConnectionResetError(unittest.TestCase):
-    
+class TestBackoffError(unittest.TestCase):
+    '''
+    Test that backoff logic works properly. Mocked some common method to test the backoff including
+    filter_selected_fields_many, write_records , metrics, write_bookmark, write_state, sobject_to_dict,
+    get_bookmark, write_schema, get_core_schema, get_selected_fields, time.sleep.
+    '''
     @mock.patch("tap_bing_ads.create_sdk_client", return_value = '')
     @mock.patch("tap_bing_ads.CustomServiceClient")
-    def test_connection_reset_error_get_account(self, mock_get_account, mock_create_sdk_client, 
-                                                    mock_get_selected_fields, mock_get_core_schema, 
-                                                    mock_write_schema, mock_get_bookmark, 
-                                                    mock_sobject_to_dict, mock_write_state, 
-                                                    mock_write_bookmark, mock_metrics, mock_write_records, 
+    def test_connection_reset_error_get_account(self, mock_get_account, mock_create_sdk_client,
+                                                    mock_get_selected_fields, mock_get_core_schema,
+                                                    mock_write_schema, mock_get_bookmark,
+                                                    mock_sobject_to_dict, mock_write_state,
+                                                    mock_write_bookmark, mock_metrics, mock_write_records,
                                                     mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap retry on the connection reset error 5 times.
+        '''
         mock_get_account.side_effect = socket.error(104, 'Connection reset by peer')
         try:
             tap_bing_ads.sync_accounts_stream(['i1'], {})
@@ -82,12 +89,15 @@ class TestConnectionResetError(unittest.TestCase):
         
     @mock.patch("tap_bing_ads.create_sdk_client", return_value = '')
     @mock.patch("tap_bing_ads.CustomServiceClient")
-    def test_socket_timeout__error_get_account(self, mock_get_account, mock_create_sdk_client, 
-                                                    mock_get_selected_fields, mock_get_core_schema, 
-                                                    mock_write_schema, mock_get_bookmark, 
-                                                    mock_sobject_to_dict, mock_write_state, 
-                                                    mock_write_bookmark, mock_metrics, mock_write_records, 
+    def test_socket_timeout__error_get_account(self, mock_get_account, mock_create_sdk_client,
+                                                    mock_get_selected_fields, mock_get_core_schema,
+                                                    mock_write_schema, mock_get_bookmark,
+                                                    mock_sobject_to_dict, mock_write_state,
+                                                    mock_write_bookmark, mock_metrics, mock_write_records,
                                                     mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap retry on the socket timeout error 5 times.
+        '''
         mock_get_account.side_effect = socket.timeout()
         try:
             tap_bing_ads.sync_accounts_stream(['i1'], {})
@@ -98,12 +108,15 @@ class TestConnectionResetError(unittest.TestCase):
         
     @mock.patch("tap_bing_ads.create_sdk_client", return_value = '')
     @mock.patch("tap_bing_ads.CustomServiceClient")
-    def test_http_timeout__error_get_account(self, mock_get_account, mock_create_sdk_client, 
-                                                    mock_get_selected_fields, mock_get_core_schema, 
-                                                    mock_write_schema, mock_get_bookmark, 
-                                                    mock_sobject_to_dict, mock_write_state, 
-                                                    mock_write_bookmark, mock_metrics, mock_write_records, 
+    def test_http_timeout__error_get_account(self, mock_get_account, mock_create_sdk_client,
+                                                    mock_get_selected_fields, mock_get_core_schema,
+                                                    mock_write_schema, mock_get_bookmark,
+                                                    mock_sobject_to_dict, mock_write_state,
+                                                    mock_write_bookmark, mock_metrics, mock_write_records,
                                                     mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap retry on the http timeout error 5 times.
+        '''
         with open('tests/base.py') as f:
             mock_get_account.side_effect = HTTPError('url', 408, 'Request Timeout', {}, f)
         try:
@@ -115,12 +128,15 @@ class TestConnectionResetError(unittest.TestCase):
         
     @mock.patch("tap_bing_ads.create_sdk_client", return_value = '')
     @mock.patch("tap_bing_ads.CustomServiceClient")
-    def test_internal_server_error_get_account(self, mock_get_account, mock_create_sdk_client, 
-                                                    mock_get_selected_fields, mock_get_core_schema, 
-                                                    mock_write_schema, mock_get_bookmark, 
-                                                    mock_sobject_to_dict, mock_write_state, 
-                                                    mock_write_bookmark, mock_metrics, mock_write_records, 
+    def test_internal_server_error_get_account(self, mock_get_account, mock_create_sdk_client,
+                                                    mock_get_selected_fields, mock_get_core_schema,
+                                                    mock_write_schema, mock_get_bookmark,
+                                                    mock_sobject_to_dict, mock_write_state,
+                                                    mock_write_bookmark, mock_metrics, mock_write_records,
                                                     mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap retry on the 500 internal server error 5 times.
+        '''
         with open('tests/base.py') as f:
             mock_get_account.side_effect = HTTPError('url', 500, 'Internal Server Error', {}, f)
         try:
@@ -132,13 +148,15 @@ class TestConnectionResetError(unittest.TestCase):
         
     @mock.patch("tap_bing_ads.create_sdk_client", return_value = '')
     @mock.patch("tap_bing_ads.CustomServiceClient")
-    def test_transport_error_get_account(self, mock_get_account, mock_create_sdk_client, 
-                                                
-                                                           mock_get_selected_fields, mock_get_core_schema, 
-                                                           mock_write_schema, mock_get_bookmark, 
-                                                           mock_sobject_to_dict, mock_write_state, 
-                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many,mock_sleep):
+    def test_transport_error_get_account(self, mock_get_account, mock_create_sdk_client,
+                                                mock_get_selected_fields, mock_get_core_schema,
+                                                mock_write_schema, mock_get_bookmark,
+                                                mock_sobject_to_dict, mock_write_state, 
+                                                mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap retry on the Transport error 5 times.
+        '''
         with open('tests/base.py') as f:
             mock_get_account.side_effect = TransportError('url', 500, 'Internal Server Error')
         try:
@@ -156,6 +174,9 @@ class TestConnectionResetError(unittest.TestCase):
                                         mock_sobject_to_dict, mock_write_state, 
                                         mock_write_bookmark, mock_metrics, mock_write_records, 
                                         mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap does not retry on the 400 error.
+        '''
         with open('tests/base.py') as f:
             mock_get_account.side_effect = HTTPError('url', 400, 'Bad Request', {}, f)
         try:
@@ -174,6 +195,9 @@ class TestConnectionResetError(unittest.TestCase):
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
                                                            mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap retry on the SSLEOFError 5 times.
+        '''
         with open('tests/base.py') as f:
             mock_get_account.side_effect = ssl.SSLEOFError('EOF occurred in violation of protocol')
         try:
@@ -188,6 +212,9 @@ class TestConnectionResetError(unittest.TestCase):
                                                         mock_sobject_to_dict, mock_write_state, 
                                                         mock_write_bookmark, mock_metrics, mock_write_records, 
                                                         mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap retry on the connection reset error 5 times.
+        '''
         mock_client = MockClient(socket.error(104, 'Connection reset by peer'))
         try:
             tap_bing_ads.sync_campaigns(mock_client, '', [])
@@ -201,6 +228,9 @@ class TestConnectionResetError(unittest.TestCase):
                                                         mock_sobject_to_dict, mock_write_state, 
                                                         mock_write_bookmark, mock_metrics, mock_write_records, 
                                                         mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap retry on the socket timeout error 5 times.
+        '''
         mock_client = MockClient(socket.timeout())
         try:
             tap_bing_ads.sync_campaigns(mock_client, '', [])
@@ -214,6 +244,9 @@ class TestConnectionResetError(unittest.TestCase):
                                                     mock_sobject_to_dict, mock_write_state, 
                                                     mock_write_bookmark, mock_metrics, mock_write_records, 
                                                     mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap retry on the http timeout error 5 times.
+        '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 408, 'Request Timeout', {}, f))
         try:
@@ -228,6 +261,9 @@ class TestConnectionResetError(unittest.TestCase):
                                                         mock_sobject_to_dict, mock_write_state, 
                                                         mock_write_bookmark, mock_metrics, mock_write_records, 
                                                         mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap retry on the 500 internal server error 5 times.
+        '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 500, 'Internal Server Error', {}, f))
         try:
@@ -256,6 +292,9 @@ class TestConnectionResetError(unittest.TestCase):
                                             mock_sobject_to_dict, mock_write_state, 
                                             mock_write_bookmark, mock_metrics, mock_write_records, 
                                             mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap does not retry on the 400 error.
+        '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 400, 'Bad Request', {}, f))
         try:
@@ -270,6 +309,9 @@ class TestConnectionResetError(unittest.TestCase):
                                                 mock_sobject_to_dict, mock_write_state, 
                                                 mock_write_bookmark, mock_metrics, mock_write_records, 
                                                 mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap retry on the SSLEOFError 5 times.
+        '''
         with open('tests/base.py') as f:
             mock_client = MockClient(ssl.SSLEOFError('EOF occurred in violation of protocol'))
         try:
@@ -283,6 +325,9 @@ class TestConnectionResetError(unittest.TestCase):
                                                         mock_sobject_to_dict, mock_write_state, 
                                                         mock_write_bookmark, mock_metrics, mock_write_records, 
                                                         mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap retry on the connection reset error 5 times.
+        '''
         mock_client = MockClient(socket.error(104, 'Connection reset by peer'))
         try:
             tap_bing_ads.sync_ad_groups(mock_client, '', ['dummy_campaign_id'], [])
@@ -296,6 +341,9 @@ class TestConnectionResetError(unittest.TestCase):
                                                         mock_sobject_to_dict, mock_write_state, 
                                                         mock_write_bookmark, mock_metrics, mock_write_records, 
                                                         mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap retry on the socket timeout error 5 times.
+        '''
         mock_client = MockClient(socket.timeout())
         try:
             tap_bing_ads.sync_ad_groups(mock_client, '', ['dummy_campaign_id'], [])
@@ -309,6 +357,9 @@ class TestConnectionResetError(unittest.TestCase):
                                                     mock_sobject_to_dict, mock_write_state, 
                                                     mock_write_bookmark, mock_metrics, mock_write_records, 
                                                     mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap retry on the http timeout error 5 times.
+        '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 408, 'Request Timeout', {}, f))
         try:
@@ -323,6 +374,9 @@ class TestConnectionResetError(unittest.TestCase):
                                                         mock_sobject_to_dict, mock_write_state, 
                                                         mock_write_bookmark, mock_metrics, mock_write_records, 
                                                         mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap retry on the 500 internal server error 5 times.
+        '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 500, 'Internal Server Error', {}, f))
         try:
@@ -337,6 +391,9 @@ class TestConnectionResetError(unittest.TestCase):
                                                         mock_sobject_to_dict, mock_write_state, 
                                                         mock_write_bookmark, mock_metrics, mock_write_records, 
                                                         mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap retry on the Transport error 5 times.
+        '''
         with open('tests/base.py') as f:
             mock_client = MockClient(TransportError('url', 500, 'Internal Server Error'))
         try:
@@ -351,6 +408,9 @@ class TestConnectionResetError(unittest.TestCase):
                                                         mock_sobject_to_dict, mock_write_state, 
                                                         mock_write_bookmark, mock_metrics, mock_write_records, 
                                                         mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap does not retry on the 400 error.
+        '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 400, 'Bad Request', {}, f))
         try:
@@ -365,6 +425,9 @@ class TestConnectionResetError(unittest.TestCase):
                                                 mock_sobject_to_dict, mock_write_state, 
                                                 mock_write_bookmark, mock_metrics, mock_write_records, 
                                                 mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap retry on the SSLEOFError 5 times.
+        '''
         with open('tests/base.py') as f:
             mock_client = MockClient(ssl.SSLEOFError('EOF occurred in violation of protocol'))
         try:
@@ -379,6 +442,9 @@ class TestConnectionResetError(unittest.TestCase):
                                                 mock_sobject_to_dict, mock_write_state, 
                                                 mock_write_bookmark, mock_metrics, mock_write_records, 
                                                 mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap retry on the connection reset error 5 times.
+        '''
         mock_client = MockClient(socket.error(104, 'Connection reset by peer'))
         try:
             tap_bing_ads.sync_ads(mock_client, ['dummy_stream'], ['dummy_ad_id'])
@@ -392,6 +458,9 @@ class TestConnectionResetError(unittest.TestCase):
                                                 mock_sobject_to_dict, mock_write_state, 
                                                 mock_write_bookmark, mock_metrics, mock_write_records, 
                                                 mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap retry on the socket timeout error 5 times.
+        '''
         mock_client = MockClient(socket.timeout())
         try:
             tap_bing_ads.sync_ads(mock_client, ['dummy_stream'], ['dummy_ad_id'])
@@ -405,6 +474,9 @@ class TestConnectionResetError(unittest.TestCase):
                                                 mock_sobject_to_dict, mock_write_state, 
                                                 mock_write_bookmark, mock_metrics, mock_write_records, 
                                                 smock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap retry on the http timeout error 5 times.
+        '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 408, 'Request Timeout', {}, f))
         try:
@@ -419,6 +491,9 @@ class TestConnectionResetError(unittest.TestCase):
                                                 mock_sobject_to_dict, mock_write_state, 
                                                 mock_write_bookmark, mock_metrics, mock_write_records, 
                                                 mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap retry on the 500 internal server error 5 times.
+        '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 500, 'Internal Server Error', {}, f))
         try:
@@ -433,6 +508,9 @@ class TestConnectionResetError(unittest.TestCase):
                                                 mock_sobject_to_dict, mock_write_state, 
                                                 mock_write_bookmark, mock_metrics, mock_write_records, 
                                                 mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap retry on the Transport error 5 times.
+        '''
         with open('tests/base.py') as f:
             mock_client = MockClient(TransportError('url', 500, 'Internal Server Error'))
         try:
@@ -447,6 +525,9 @@ class TestConnectionResetError(unittest.TestCase):
                                                 mock_sobject_to_dict, mock_write_state, 
                                                 mock_write_bookmark, mock_metrics, mock_write_records, 
                                                 mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap does not retry on the 400 error.
+        '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 400, 'Bad Request', {}, f))
         try:
@@ -461,6 +542,9 @@ class TestConnectionResetError(unittest.TestCase):
                                         mock_sobject_to_dict, mock_write_state, 
                                         mock_write_bookmark, mock_metrics, mock_write_records, 
                                         mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap retry on the SSLEOFError 5 times.
+        '''
         with open('tests/base.py') as f:
             mock_client = MockClient(ssl.SSLEOFError('EOF occurred in violation of protocol'))
         try:
@@ -477,6 +561,9 @@ class TestConnectionResetError(unittest.TestCase):
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
                                                            mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap retry on the connection reset error 5 times.
+        '''
         mock_client = MockClient(socket.error(104, 'Connection reset by peer'))
         try:
             tap_bing_ads.get_report_request_id(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date', 'dummy_start_key',
@@ -509,6 +596,9 @@ class TestConnectionResetError(unittest.TestCase):
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
                                                            mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap retry on the http timeout error 5 times.
+        '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 408, 'Request Timeout', {}, f))
         try:
@@ -526,6 +616,9 @@ class TestConnectionResetError(unittest.TestCase):
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
                                                            mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap retry on the 500 internal server error 5 times.
+        '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 500, 'Internal Server Error', {}, f))
         try:
@@ -543,6 +636,9 @@ class TestConnectionResetError(unittest.TestCase):
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
                                                            mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap retry on the Transport error 5 times.
+        '''
         with open('tests/base.py') as f:
             mock_client = MockClient(TransportError('url', 500, 'Internal Server Error'))
         try:
@@ -560,6 +656,9 @@ class TestConnectionResetError(unittest.TestCase):
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
                                                            mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap does not retry on the 400 error.
+        '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 400, 'Bad Request', {}, f))
         try:
@@ -577,6 +676,9 @@ class TestConnectionResetError(unittest.TestCase):
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
                                                            mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap retry on the SSLEOFError 5 times.
+        '''
         with open('tests/base.py') as f:
             mock_client = MockClient(ssl.SSLEOFError('EOF occurred in violation of protocol'))
         try:
@@ -592,6 +694,9 @@ class TestConnectionResetError(unittest.TestCase):
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
                                                            mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap retry on the connection reset error 5 times.
+        '''
         mock_client = MockClient(socket.error(104, 'Connection reset by peer'))
         try:
             tap_bing_ads.build_report_request(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date')
@@ -605,6 +710,9 @@ class TestConnectionResetError(unittest.TestCase):
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
                                                            mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap retry on the socket timeout error 5 times.
+        '''
         mock_client = MockClient(socket.timeout())
         try:
            tap_bing_ads.build_report_request(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date')
@@ -618,6 +726,9 @@ class TestConnectionResetError(unittest.TestCase):
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
                                                            mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap retry on the http timeout error 5 times.
+        '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 408, 'Request Timeout', {}, f))
         try:
@@ -632,6 +743,9 @@ class TestConnectionResetError(unittest.TestCase):
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
                                                            mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap retry on the 500 internal server error 5 times.
+        '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 500, 'Internal Server Error', {}, f))
         try:
@@ -646,6 +760,9 @@ class TestConnectionResetError(unittest.TestCase):
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
                                                            mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap retry on the Transport error 5 times.
+        '''
         with open('tests/base.py') as f:
             mock_client = MockClient(TransportError('url', 500, 'Internal Server Error'))
         try:
@@ -660,6 +777,9 @@ class TestConnectionResetError(unittest.TestCase):
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
                                                            mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap does not retry on the 400 error.
+        '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 400, 'Bad Request', {}, f))
         try:
@@ -674,6 +794,9 @@ class TestConnectionResetError(unittest.TestCase):
                                                     mock_sobject_to_dict, mock_write_state, 
                                                     mock_write_bookmark, mock_metrics, mock_write_records, 
                                                     mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap retry on the SSLEOFError 5 times.
+        '''
         with open('tests/base.py') as f:
             mock_client = MockClient(ssl.SSLEOFError('EOF occurred in violation of protocol'))
         try:
@@ -688,6 +811,9 @@ class TestConnectionResetError(unittest.TestCase):
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
                                                            mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap retry on the connection reset error 5 times.
+        '''
         mock_client = MockClient(socket.error(104, 'Connection reset by peer'))
         try:
             tap_bing_ads.get_report_schema(mock_client, '')
@@ -701,6 +827,9 @@ class TestConnectionResetError(unittest.TestCase):
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
                                                            mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap retry on the socket timeout error 5 times.
+        '''
         mock_client = MockClient(socket.timeout())
         try:
            tap_bing_ads.get_report_schema(mock_client, '')
@@ -714,6 +843,9 @@ class TestConnectionResetError(unittest.TestCase):
                                                         mock_sobject_to_dict, mock_write_state, 
                                                         mock_write_bookmark, mock_metrics, mock_write_records, 
                                                         mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap retry on the http timeout error 5 times.
+        '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 408, 'Request Timeout', {}, f))
         try:
@@ -728,6 +860,9 @@ class TestConnectionResetError(unittest.TestCase):
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
                                                            mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap retry on the 500 internal server error 5 times.
+        '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 500, 'Internal Server Error', {}, f))
         try:
@@ -742,6 +877,9 @@ class TestConnectionResetError(unittest.TestCase):
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
                                                            mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap retry on the Transport error 5 times.
+        '''
         with open('tests/base.py') as f:
             mock_client = MockClient(TransportError('url', 500, 'Internal Server Error'))
         try:
@@ -756,6 +894,9 @@ class TestConnectionResetError(unittest.TestCase):
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
                                                            mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap does not retry on the 400 error.
+        '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 400, 'Bad Request', {}, f))
         try:
@@ -770,6 +911,9 @@ class TestConnectionResetError(unittest.TestCase):
                                                 mock_sobject_to_dict, mock_write_state, 
                                                 mock_write_bookmark, mock_metrics, mock_write_records, 
                                                 mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap retry on the SSLEOFError 5 times.
+        '''
         with open('tests/base.py') as f:
             mock_client = MockClient(ssl.SSLEOFError('EOF occurred in violation of protocol'))
         try:
@@ -784,6 +928,9 @@ class TestConnectionResetError(unittest.TestCase):
                                                     mock_sobject_to_dict, mock_write_state, 
                                                     mock_write_bookmark, mock_metrics, mock_write_records, 
                                                     mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap retry on the connection reset error 5 times.
+        '''
         mock_client = MockClient(socket.error(104, 'Connection reset by peer'))
         try:
             tap_bing_ads.get_type_map(mock_client)
@@ -797,6 +944,9 @@ class TestConnectionResetError(unittest.TestCase):
                                                     mock_sobject_to_dict, mock_write_state, 
                                                     mock_write_bookmark, mock_metrics, mock_write_records, 
                                                     mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap retry on the socket timeout error 5 times.
+        '''
         mock_client = MockClient(socket.timeout())
         try:
            tap_bing_ads.get_type_map(mock_client)
@@ -810,6 +960,9 @@ class TestConnectionResetError(unittest.TestCase):
                                                 mock_sobject_to_dict, mock_write_state, 
                                                 mock_write_bookmark, mock_metrics, mock_write_records, 
                                                 mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap retry on the http timeout error 5 times.
+        '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 408, 'Request Timeout', {}, f))
         try:
@@ -824,6 +977,9 @@ class TestConnectionResetError(unittest.TestCase):
                                                     mock_sobject_to_dict, mock_write_state, 
                                                     mock_write_bookmark, mock_metrics, mock_write_records, 
                                                     mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap retry on the 500 internal server error 5 times.
+        '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 500, 'Internal Server Error', {}, f))
         try:
@@ -838,6 +994,9 @@ class TestConnectionResetError(unittest.TestCase):
                                                     mock_sobject_to_dict, mock_write_state, 
                                                     mock_write_bookmark, mock_metrics, mock_write_records, 
                                                     mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap retry on the Transport error 5 times.
+        '''
         with open('tests/base.py') as f:
             mock_client = MockClient(TransportError('url', 500, 'Internal Server Error'))
         try:
@@ -852,6 +1011,9 @@ class TestConnectionResetError(unittest.TestCase):
                                                     mock_sobject_to_dict, mock_write_state, 
                                                     mock_write_bookmark, mock_metrics, mock_write_records, 
                                                     mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap does not retry on the 400 error.
+        '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 400, 'Bad Request', {}, f))
         try:
@@ -866,6 +1028,9 @@ class TestConnectionResetError(unittest.TestCase):
                                             mock_sobject_to_dict, mock_write_state, 
                                             mock_write_bookmark, mock_metrics, mock_write_records, 
                                             mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap retry on the SSLEOFError 5 times.
+        '''
         with open('tests/base.py') as f:
             mock_client = MockClient(ssl.SSLEOFError('EOF occurred in violation of protocol'))
         try:
@@ -880,6 +1045,9 @@ class TestConnectionResetError(unittest.TestCase):
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
                                                            mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap retry on the connection reset error 5 times.
+        '''
         mock_client = MockClient(socket.error(104, 'Connection reset by peer'))
         try:
             await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
@@ -893,6 +1061,9 @@ class TestConnectionResetError(unittest.TestCase):
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
                                                            mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap retry on the socket timeout error 5 times.
+        '''
         mock_client = MockClient(socket.timeout())
         try:
            await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
@@ -906,6 +1077,9 @@ class TestConnectionResetError(unittest.TestCase):
                                                         mock_sobject_to_dict, mock_write_state, 
                                                         mock_write_bookmark, mock_metrics, mock_write_records, 
                                                         mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap retry on the http timeout error 5 times.
+        '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 408, 'Request Timeout', {}, f))
         try:
@@ -920,6 +1094,9 @@ class TestConnectionResetError(unittest.TestCase):
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
                                                            mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap retry on the 500 internal server error 5 times.
+        '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 500, 'Internal Server Error', {}, f))
         try:
@@ -934,6 +1111,9 @@ class TestConnectionResetError(unittest.TestCase):
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
                                                            mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap retry on the Transport error 5 times.
+        '''
         with open('tests/base.py') as f:
             mock_client = MockClient(TransportError('url', 500, 'Internal Server Error'))
         try:
@@ -948,6 +1128,9 @@ class TestConnectionResetError(unittest.TestCase):
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
                                                            mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap does not retry on the 400 error.
+        '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 400, 'Bad Request', {}, f))
         try:
@@ -962,6 +1145,9 @@ class TestConnectionResetError(unittest.TestCase):
                                                     mock_sobject_to_dict, mock_write_state, 
                                                     mock_write_bookmark, mock_metrics, mock_write_records, 
                                                     mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap retry on the SSLEOFError 5 times.
+        '''
         with open('tests/base.py') as f:
             mock_client = MockClient(ssl.SSLEOFError('EOF occurred in violation of protocol'))
         try:
@@ -1000,6 +1186,9 @@ class TestConnectionResetError(unittest.TestCase):
                                                     mock_sobject_to_dict, mock_write_state, 
                                                     mock_write_bookmark, mock_metrics, mock_write_records, 
                                                     mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap retry on the socket timeout error 5 times.
+        '''
         mock_oauth.return_value = ''
         mock_client.side_effect = socket.timeout()
         try:
@@ -1019,6 +1208,9 @@ class TestConnectionResetError(unittest.TestCase):
                                                         mock_sobject_to_dict, mock_write_state, 
                                                         mock_write_bookmark, mock_metrics, mock_write_records, 
                                                         mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap retry on the http timeout error 5 times.
+        '''
         mock_oauth.return_value = ''
         with open('tests/base.py') as f:
             mock_client.side_effect = HTTPError('url', 408, 'Request Timeout', {}, f)
@@ -1039,6 +1231,9 @@ class TestConnectionResetError(unittest.TestCase):
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
                                                            mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap retry on the 500 internal server error 5 times.
+        '''
         mock_oauth.return_value = ''
         with open('tests/base.py') as f:
             mock_client.side_effect = HTTPError('url', 500, 'Internal Server Error', {}, f)
@@ -1059,6 +1254,9 @@ class TestConnectionResetError(unittest.TestCase):
                                                     mock_sobject_to_dict, mock_write_state, 
                                                     mock_write_bookmark, mock_metrics, mock_write_records, 
                                                     mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap retry on the Transport error 5 times.
+        '''
         mock_oauth.return_value = ''
         with open('tests/base.py') as f:
             mock_client.side_effect = TransportError('url', 500, 'Internal Server Error')
@@ -1079,6 +1277,9 @@ class TestConnectionResetError(unittest.TestCase):
                                                 mock_sobject_to_dict, mock_write_state, 
                                                 mock_write_bookmark, mock_metrics, mock_write_records, 
                                                 mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap does not retry on the 400 error.
+        '''
         mock_oauth.return_value = ''
         with open('tests/base.py') as f:
             mock_client.side_effect = HTTPError('url', 400, 'Bad Request', {}, f)
@@ -1100,6 +1301,9 @@ class TestConnectionResetError(unittest.TestCase):
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
                                                            mock_filter_selected_fields_many,mock_sleep):
+        '''
+        Test that tap retry on the SSLEOFError 5 times.
+        '''
         mock_oauth.return_value = ''
         with open('tests/base.py') as f:
             mock_client.side_effect = ssl.SSLEOFError('EOF occurred in violation of protocol')


### PR DESCRIPTION
# Description of change
- Added retry logic for following below errors,
  - ConnectionResetError
  - socket.timeout 
  - HTTP Error 408: Request Timeout
  - HTTP Error 500: Internal Server Error
  - URL Error
  - ssl.SSLEOFError
  - 408 Exception
- Retry above all errors until 60 seconds.
- If after passing 60 seconds the same error comes, then it will be raised.

# Manual QA steps
 - Raise the following error manually and check that it retries until 60 seconds.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
