### PR TITLE
Tdl 15861 implement request timeout

### DIFF
--- a/tap_bing_ads/__init__.py
+++ b/tap_bing_ads/__init__.py
@@ -763,7 +763,7 @@ async def poll_report(client, account_id, report_name, start_date, end_date, req
 def log_retry_attempt(details):
     LOGGER.info('Retrieving report timed out, triggering retry #%d', details.get('tries'))
 
-# backoff for 60 seconds to keep consistent withother backoffs when URLError occurs indicating request timeout
+# backoff for 60 seconds to keep consistent with other backoffs when URLError occurs indicating request timeout
 @backoff.on_exception(backoff.expo,
                       urllib.error.URLError,
                       giveup=is_timeout_error(),

--- a/tap_bing_ads/__init__.py
+++ b/tap_bing_ads/__init__.py
@@ -748,13 +748,9 @@ async def poll_report(client, account_id, report_name, start_date, end_date, req
 def log_retry_attempt(details):
     LOGGER.info('Retrieving report timed out, triggering retry #%d', details.get('tries'))
 
-# backoff for 60 seconds to keep consistent with other backoffs when URLError occurs indicating request timeout
-@backoff.on_exception(backoff.expo,
-                      urllib.error.URLError,
-                      max_time=60,
-                      factor=2)
+# retry the request for 5 times when Timeout error occurs
 @backoff.on_exception(backoff.constant,
-                      requests.exceptions.ConnectionError,
+                      (requests.exceptions.Timeout ,requests.exceptions.ConnectionError),
                       max_tries=5,
                       on_backoff=log_retry_attempt)
 def stream_report(stream_name, report_name, url, report_time):

--- a/tap_bing_ads/__init__.py
+++ b/tap_bing_ads/__init__.py
@@ -65,7 +65,9 @@ def should_retry_httperror(exception):
     """ Retry 500-range and 408 errors. """
     try:
         if exception.code == 408:
-            return True
+            return True        
+
+        # return true if the status code is between 500 to 600
         return 500 <= exception.code < 600
     except AttributeError:
         # As ConnectionError, socket.timeout, SSLError, Transport does not have `code` property, it throws AttributeError.

--- a/tap_bing_ads/__init__.py
+++ b/tap_bing_ads/__init__.py
@@ -65,7 +65,7 @@ def should_retry_httperror(exception):
     """ Retry 500-range and 408 errors. """
     try:
         if exception.code == 408:
-            return True        
+            return True
 
         # return true if the status code is between 500 to 600
         return 500 <= exception.code < 600

--- a/tap_bing_ads/__init__.py
+++ b/tap_bing_ads/__init__.py
@@ -66,7 +66,7 @@ def should_retry_httperror(exception):
     try:
         if exception.code == 408:
             return True
-    
+     
         # return true if the status code is between 500 to 600
         return 500 <= exception.code < 600
     except AttributeError:

--- a/tap_bing_ads/__init__.py
+++ b/tap_bing_ads/__init__.py
@@ -66,7 +66,7 @@ def should_retry_httperror(exception):
     try:
         if exception.code == 408:
             return True
-
+    
         # return true if the status code is between 500 to 600
         return 500 <= exception.code < 600
     except AttributeError:

--- a/tap_bing_ads/__init__.py
+++ b/tap_bing_ads/__init__.py
@@ -147,9 +147,8 @@ class CustomServiceClient(ServiceClient):
         self._options = kwargs
         kwargs = ServiceClient._ensemble_header(self.authorization_data, **self._options)
         kwargs['headers']['User-Agent'] = get_user_agent()
-        request_timeout = get_request_timeout()
         # setting the timeout parameter using the set_options which sets timeout in the _soap_client
-        kwargs['timeout'] = request_timeout
+        kwargs['timeout'] = get_request_timeout()
         self._soap_client.set_options(**kwargs)
 
 @bing_ads_error_handling

--- a/tap_bing_ads/__init__.py
+++ b/tap_bing_ads/__init__.py
@@ -761,7 +761,7 @@ async def poll_report(client, account_id, report_name, start_date, end_date, req
 def log_retry_attempt(details):
     LOGGER.info('Retrieving report timed out, triggering retry #%d', details.get('tries'))
 
-# backoff when URLError occurs indicating request timeout
+# backoff for 60 seconds to keep consistent withother backoffs when URLError occurs indicating request timeout
 @backoff.on_exception(backoff.expo,
                       urllib.error.URLError,
                       giveup=is_timeout_error(),

--- a/tests/unittests/test_request_timeout.py
+++ b/tests/unittests/test_request_timeout.py
@@ -88,33 +88,13 @@ class TestBackoffError(unittest.TestCase):
         # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
 
-    @mock.patch("tap_bing_ads.create_sdk_client", return_value = '')
-    @mock.patch("tap_bing_ads.CustomServiceClient")
-    @mock.patch("time.sleep")
-    def test_url_error_no_timeout_get_account(self, mock_sleep, mock_get_account, mock_create_sdk_client,
-                                                    mock_get_selected_fields, mock_get_core_schema,
-                                                    mock_write_schema, mock_get_bookmark,
-                                                    mock_sobject_to_dict, mock_write_state,
-                                                    mock_write_bookmark, mock_metrics, mock_write_records,
-                                                    mock_filter_selected_fields_many):
-        '''
-        Test that tap does not retry on the url error no timeout.
-        '''
-        mock_get_account.side_effect = URLError('_ssl.c:1059: The handshake operation did not succeed')
-        try:
-            tap_bing_ads.sync_accounts_stream(['i1'], {})
-        except URLError:
-            pass
-        # verify the code did not back off and requested for 1 time
-        self.assertEqual(mock_get_account.call_count, 1)
-
     def test_url_error_sync_campaigns(self, mock_get_selected_fields, mock_get_core_schema, 
                                                         mock_write_schema, mock_get_bookmark, 
                                                         mock_sobject_to_dict, mock_write_state, 
                                                         mock_write_bookmark, mock_metrics, mock_write_records, 
                                                         mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the connection reset error for 1 minute.
+        Test that tap retry on the timeout error for 1 minute.
         '''
         mock_client = MockClient(URLError('_ssl.c:1059: The handshake operation timed out'))
         before_time = datetime.datetime.now()
@@ -127,23 +107,6 @@ class TestBackoffError(unittest.TestCase):
         # verify the code backed off for 60 seconds
         # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
-
-    @mock.patch("time.sleep")
-    def test_url_error_no_timeout_sync_campaigns(self, mock_sleep, mock_get_selected_fields, mock_get_core_schema, 
-                                                        mock_write_schema, mock_get_bookmark, 
-                                                        mock_sobject_to_dict, mock_write_state, 
-                                                        mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                        mock_filter_selected_fields_many):
-        '''
-        Test that tap does not retry on the url error no timeout.
-        '''
-        mock_client = MockClient(URLError('_ssl.c:1059: The handshake operation did not succeed'))
-        try:
-            tap_bing_ads.sync_campaigns(mock_client, '', [])
-        except URLError:
-            pass
-        # verify the code did not back off and requested for 1 time
-        self.assertEqual(mock_client.call_count, 1)
 
     def test_url_error_sync_ad_groups(self, mock_get_selected_fields, mock_get_core_schema, 
                                                         mock_write_schema, mock_get_bookmark, 
@@ -151,7 +114,7 @@ class TestBackoffError(unittest.TestCase):
                                                         mock_write_bookmark, mock_metrics, mock_write_records, 
                                                         mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the connection reset error for 1 minute.
+        Test that tap retry on the timeout error for 1 minute.
         '''
         mock_client = MockClient(URLError('_ssl.c:1059: The handshake operation timed out'))
         before_time = datetime.datetime.now()
@@ -164,23 +127,6 @@ class TestBackoffError(unittest.TestCase):
         # verify the code backed off for 60 seconds
         # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
-
-    @mock.patch("time.sleep")
-    def test_url_error_no_timeout_sync_ad_groups(self, mock_sleep, mock_get_selected_fields, mock_get_core_schema, 
-                                                        mock_write_schema, mock_get_bookmark, 
-                                                        mock_sobject_to_dict, mock_write_state, 
-                                                        mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                        mock_filter_selected_fields_many):
-        '''
-        Test that tap does not retry on the url error no timeout.
-        '''
-        mock_client = MockClient(URLError('_ssl.c:1059: The handshake operation did not succeed'))
-        try:
-            tap_bing_ads.sync_ad_groups(mock_client, '', ['dummy_campaign_id'], [])
-        except URLError:
-            pass
-        # verify the code does not back off and requested for 1 time
-        self.assertEqual(mock_client.call_count, 1)
 
     def test_url_error_sync_ads(self, mock_get_selected_fields, mock_get_core_schema, 
                                                 mock_write_schema, mock_get_bookmark, 
@@ -188,7 +134,7 @@ class TestBackoffError(unittest.TestCase):
                                                 mock_write_bookmark, mock_metrics, mock_write_records, 
                                                 mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the connection reset error for 1 minute.
+        Test that tap retry on the timeout error for 1 minute.
         '''
         mock_client = MockClient(URLError('_ssl.c:1059: The handshake operation timed out'))
         before_time = datetime.datetime.now()
@@ -200,24 +146,7 @@ class TestBackoffError(unittest.TestCase):
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
         # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
-
-    @mock.patch("time.sleep")
-    def test_url_error_no_timeout_sync_ads(self, mock_sleep, mock_get_selected_fields, mock_get_core_schema, 
-                                                mock_write_schema, mock_get_bookmark, 
-                                                mock_sobject_to_dict, mock_write_state, 
-                                                mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                mock_filter_selected_fields_many):
-        '''
-        Test that tap does not retry on the url error no timeout.
-        '''
-        mock_client = MockClient(URLError('_ssl.c:1059: The handshake operation did not succeed'))
-        try:
-            tap_bing_ads.sync_ads(mock_client, ['dummy_stream'], ['dummy_ad_id'])
-        except URLError:
-            pass
-        # verify the code does not back off and requested for 1 time
-        self.assertEqual(mock_client.call_count, 1)    
+        self.assertGreaterEqual(time_difference, 60) 
 
     @mock.patch("tap_bing_ads.build_report_request")
     def test_url_error_get_report_request_id(self, mock_build_report_request, 
@@ -227,7 +156,7 @@ class TestBackoffError(unittest.TestCase):
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
                                                            mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the connection reset error for 1 minute.
+        Test that tap retry on the timeout error for 1 minute.
         '''
         mock_client = MockClient(URLError('_ssl.c:1059: The handshake operation timed out'))
         before_time = datetime.datetime.now()
@@ -241,26 +170,6 @@ class TestBackoffError(unittest.TestCase):
         # verify the code backed off for 60 seconds
         # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
-
-    @mock.patch("tap_bing_ads.build_report_request")
-    @mock.patch("time.sleep")
-    def test_url_error_no_timeout_get_report_request_id(self, mock_sleep, mock_build_report_request, 
-                                                           mock_get_selected_fields, mock_get_core_schema, 
-                                                           mock_write_schema, mock_get_bookmark, 
-                                                           mock_sobject_to_dict, mock_write_state, 
-                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many):
-        '''
-        Test that tap does not retry on the url error no timeout.
-        '''
-        mock_client = MockClient(URLError('_ssl.c:1059: The handshake operation did not succeed'))
-        try:
-            tap_bing_ads.get_report_request_id(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date', 'dummy_start_key',
-                                                force_refresh = True)
-        except URLError:
-            pass
-        # verify the code did not back off and requested for 1 time
-        self.assertEqual(mock_client.call_count, 1)
 
     def test_url_error_build_report_request(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
@@ -268,7 +177,7 @@ class TestBackoffError(unittest.TestCase):
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
                                                            mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the connection reset error for 1 minute.
+        Test that tap retry on the timeout error for 1 minute.
         '''
         mock_client = MockClient(URLError('_ssl.c:1059: The handshake operation timed out'))
         before_time = datetime.datetime.now()
@@ -281,23 +190,6 @@ class TestBackoffError(unittest.TestCase):
         # verify the code backed off for 60 seconds
         # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
-
-    @mock.patch("time.sleep")
-    def test_url_error_no_timeout_build_report_request(self, mock_sleep, mock_get_selected_fields, mock_get_core_schema, 
-                                                           mock_write_schema, mock_get_bookmark, 
-                                                           mock_sobject_to_dict, mock_write_state, 
-                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many):
-        '''
-        Test that tap does not on the url no timeout error.
-        '''
-        mock_client = MockClient(URLError('_ssl.c:1059: The handshake operation did not succeed'))
-        try:
-            tap_bing_ads.build_report_request(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date')
-        except URLError:
-            pass
-        # verify the code did not back off and requested for 1 time
-        self.assertEqual(mock_client.call_count, 1)    
 
     def test_url_error_get_type_map(self, mock_get_selected_fields, mock_get_core_schema, 
                                                     mock_write_schema, mock_get_bookmark, 
@@ -305,7 +197,7 @@ class TestBackoffError(unittest.TestCase):
                                                     mock_write_bookmark, mock_metrics, mock_write_records, 
                                                     mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the connection reset error for 1 minute.
+        Test that tap retry on the timeout error for 1 minute.
         '''
         mock_client = MockClient(URLError('_ssl.c:1059: The handshake operation timed out'))
         before_time = datetime.datetime.now()
@@ -318,23 +210,6 @@ class TestBackoffError(unittest.TestCase):
         # verify the code backed off for 60 seconds
         # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
-
-    @mock.patch("time.sleep")
-    def test_url_no_timeout_error_get_type_map(self, mock_sleep, mock_get_selected_fields, mock_get_core_schema, 
-                                                           mock_write_schema, mock_get_bookmark, 
-                                                           mock_sobject_to_dict, mock_write_state, 
-                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many):
-        '''
-        Test that tap does not retry on the url no timeout error.
-        '''
-        mock_client = MockClient(URLError('_ssl.c:1059: The handshake operation did not succeed'))
-        try:
-            tap_bing_ads.get_type_map(mock_client)
-        except URLError:
-            pass
-        # verify the code did not back off and requested for 1 time
-        self.assertEqual(mock_client.call_count, 1)
 
     def test_url_error_get_report_schema(self, mock_get_selected_fields, mock_get_core_schema, 
                                                     mock_write_schema, mock_get_bookmark, 
@@ -342,7 +217,7 @@ class TestBackoffError(unittest.TestCase):
                                                     mock_write_bookmark, mock_metrics, mock_write_records, 
                                                     mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the connection reset error for 1 minute.
+        Test that tap retry on the timeout error for 1 minute.
         '''
         mock_client = MockClient(URLError('_ssl.c:1059: The handshake operation timed out'))
         before_time = datetime.datetime.now()
@@ -355,23 +230,6 @@ class TestBackoffError(unittest.TestCase):
         # verify the code backed off for 60 seconds
         # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
-
-    @mock.patch("time.sleep")
-    def test_url_no_timeout_error_get_report_schema(self, mock_sleep, mock_get_selected_fields, mock_get_core_schema, 
-                                                           mock_write_schema, mock_get_bookmark, 
-                                                           mock_sobject_to_dict, mock_write_state, 
-                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many):
-        '''
-        Test that tap does not retry on the url no timeout error.
-        '''
-        mock_client = MockClient(URLError('_ssl.c:1059: The handshake operation did not succeed'))
-        try:
-            tap_bing_ads.get_report_schema(mock_client, '')
-        except URLError:
-            pass
-        # verify the code did not back off and requested for 1 time
-        self.assertEqual(mock_client.call_count, 1)
 
     async def test_url_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
@@ -379,7 +237,7 @@ class TestBackoffError(unittest.TestCase):
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
                                                            mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the connection reset error for 1 minute.
+        Test that tap retry on the timeout error for 1 minute.
         '''
         mock_client = MockClient(URLError('_ssl.c:1059: The handshake operation timed out'))
         before_time = datetime.datetime.now()
@@ -392,23 +250,6 @@ class TestBackoffError(unittest.TestCase):
         # verify the code backed off for 60 seconds
         # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
-
-    @mock.patch("time.sleep")
-    async def test_url_error_no_timeout_poll_report(self, mock_sleep, mock_get_selected_fields, mock_get_core_schema, 
-                                                           mock_write_schema, mock_get_bookmark, 
-                                                           mock_sobject_to_dict, mock_write_state, 
-                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many):
-        '''
-        Test that tap does not retry on the url error no timeout.
-        '''
-        mock_client = MockClient(URLError('_ssl.c:1059: The handshake operation did not succeed'))
-        try:
-            await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
-        except URLError:
-            pass
-        # verify the code did not back off and requested for 1 time
-        self.assertEqual(mock_client.call_count, 1)
 
     @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
     @mock.patch("bingads.OAuthWebAuthCodeGrant.request_oauth_tokens_by_refresh_token")
@@ -421,7 +262,7 @@ class TestBackoffError(unittest.TestCase):
                                                         mock_write_bookmark, mock_metrics, mock_write_records, 
                                                         mock_filter_selected_fields_many):
         '''
-        Test that tap retry on the connection reset error for 1 minute.
+        Test that tap retry on the timeout error for 1 minute.
         '''
         mock_oauth.return_value = ''
         mock_client.side_effect = URLError('_ssl.c:1059: The handshake operation timed out')
@@ -435,29 +276,6 @@ class TestBackoffError(unittest.TestCase):
         # verify the code backed off for 60 seconds
         # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
-
-    @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
-    @mock.patch("bingads.OAuthWebAuthCodeGrant.request_oauth_tokens_by_refresh_token")
-    @mock.patch("bingads.AuthorizationData", return_value = '')
-    @mock.patch("tap_bing_ads.CustomServiceClient")
-    @mock.patch("time.sleep")
-    def test_url_error_no_timeout_create_sdk_client(self, mock_sleep, mock_client, mock_authorization_data, mock_oauth, mock_config,
-                                                        mock_get_selected_fields, mock_get_core_schema, 
-                                                        mock_write_schema, mock_get_bookmark, 
-                                                        mock_sobject_to_dict, mock_write_state, 
-                                                        mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                        mock_filter_selected_fields_many):
-        """
-        Test that tap does not retry on the url error no timeout.
-        """
-        mock_oauth.return_value = ''
-        mock_client.side_effect = URLError('_ssl.c:1059: The handshake operation did not succeed')
-        try:
-            tap_bing_ads.create_sdk_client('dummy_service', {})
-        except URLError:
-            pass
-        # verify the code did not back off and requested for 1 time
-        self.assertEqual(mock_oauth.call_count, 1)
 
     @mock.patch('tap_bing_ads.requests.Session.get')
     def test_url_error_stream_report(self, mocked_get, mock_get_selected_fields, mock_get_core_schema, 
@@ -480,25 +298,7 @@ class TestBackoffError(unittest.TestCase):
         # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
 
-    @mock.patch('tap_bing_ads.requests.Session.get')
-    @mock.patch("time.sleep")
-    def test_url_error_no_timeout_stream_report(self, mock_sleep, mocked_get, mock_get_selected_fields, mock_get_core_schema, 
-                                                        mock_write_schema, mock_get_bookmark, 
-                                                        mock_sobject_to_dict, mock_write_state, 
-                                                        mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                        mock_filter_selected_fields_many):
-        '''
-        Test that tap does not retry on the url error no timeout.
-        '''
-        mocked_get.side_effect = URLError('_ssl.c:1059: The handshake operation did not succeed')
-        try:
-            tap_bing_ads.stream_report('dummy_report', '', 'http://test.com', 'dummy_time')
-        except URLError:
-            pass
-        # verify the code did not back off and requested for 1 time
-        self.assertEqual(mocked_get.call_count, 1)
-
-# mock Client 
+# Mock Client 
 class MockedClient():
     def __init__(self) -> None:
         pass

--- a/tests/unittests/test_request_timeout.py
+++ b/tests/unittests/test_request_timeout.py
@@ -1,9 +1,8 @@
 import unittest
 from unittest import mock
-from unittest.case import TestCase
 import tap_bing_ads
 from urllib.error import URLError
-from tap_bing_ads import CustomServiceClient, LOGGER
+from tap_bing_ads import CustomServiceClient
 import datetime
     
 class MockClient():

--- a/tests/unittests/test_request_timeout.py
+++ b/tests/unittests/test_request_timeout.py
@@ -14,41 +14,50 @@ class MockClient():
         self.count = 0
 
     def GetCampaignsByAccountId(self, AccountId, CampaignType):
+        '''Mocked GetCampaignsByAccountId method of the Client class'''
         self.count = self.count + 1
         raise self.error
 
     def GetAdGroupsByCampaignId(self, CampaignId):
+        '''Mocked GetAdGroupsByCampaignId method of the Client class'''
         self.count = self.count + 1
         raise self.error
 
     def GetAdsByAdGroupId(self, AdGroupId, AdTypes):
+        '''Mocked GetAdsByAdGroupId method of the Client class'''
         self.count = self.count + 1
         raise self.error
 
     def PollGenerateReport(self):
+        '''Mocked PollGenerateReport method of the Client class'''
         self.count = self.count + 1
         raise self.error
 
     def SubmitGenerateReport(self, report_request):
+        '''Mocked SubmitGenerateReport method of the Client class'''
         self.count = self.count + 1
         raise self.error
 
     def PollGenerateReport(self, request_id):
+        '''Mocked PollGenerateReport method of the Client class'''
         self.count = self.count + 1
         raise self.error
 
     @property
     def factory(self):
+        '''Mocked factory property of the Client class'''
         self.count = self.count + 1
         raise self.error
 
     @property
     def soap_client(self):
+        '''Mocked soap_client property of the Client class'''
         self.count = self.count + 1
         raise self.error
 
     @property
     def call_count(self):
+        '''Mocked call_count property of the Client class'''
         return self.count
 
 @mock.patch("tap_bing_ads.filter_selected_fields_many", return_value = '')

--- a/tests/unittests/test_request_timeout.py
+++ b/tests/unittests/test_request_timeout.py
@@ -92,12 +92,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.sync_accounts_stream(['i1'], {})
         except URLError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
 
     def test_url_error_sync_campaigns(self, mock_get_selected_fields, mock_get_core_schema, 
                                                         mock_write_schema, mock_get_bookmark, 
@@ -112,12 +111,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.sync_campaigns(mock_client, '', [])
         except URLError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
 
     def test_url_error_sync_ad_groups(self, mock_get_selected_fields, mock_get_core_schema, 
                                                         mock_write_schema, mock_get_bookmark, 
@@ -132,12 +130,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.sync_ad_groups(mock_client, '', ['dummy_campaign_id'], [])
         except URLError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
 
     def test_url_error_sync_ads(self, mock_get_selected_fields, mock_get_core_schema, 
                                                 mock_write_schema, mock_get_bookmark, 
@@ -152,12 +149,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.sync_ads(mock_client, ['dummy_stream'], ['dummy_ad_id'])
         except URLError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60) 
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60) 
 
     @mock.patch("tap_bing_ads.build_report_request")
     def test_url_error_get_report_request_id(self, mock_build_report_request, 
@@ -175,12 +171,11 @@ class TestBackoffError(unittest.TestCase):
             tap_bing_ads.get_report_request_id(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date', 'dummy_start_key',
                                                 force_refresh = True)
         except URLError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
 
     def test_url_error_build_report_request(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
@@ -195,12 +190,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.build_report_request(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date')
         except URLError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
 
     def test_url_error_get_type_map(self, mock_get_selected_fields, mock_get_core_schema, 
                                                     mock_write_schema, mock_get_bookmark, 
@@ -215,12 +209,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.get_type_map(mock_client)
         except URLError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
 
     def test_url_error_get_report_schema(self, mock_get_selected_fields, mock_get_core_schema, 
                                                     mock_write_schema, mock_get_bookmark, 
@@ -235,12 +228,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.get_report_schema(mock_client, '')
         except URLError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
 
     async def test_url_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
@@ -255,12 +247,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
         except URLError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
 
     @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
     @mock.patch("bingads.OAuthWebAuthCodeGrant.request_oauth_tokens_by_refresh_token")
@@ -281,12 +272,11 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.create_sdk_client('dummy_service', {})
         except URLError:
-            pass
-        after_time = datetime.datetime.now()
-        time_difference = (after_time - before_time).total_seconds()
-        # verify the code backed off for 60 seconds
-        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-        self.assertGreaterEqual(time_difference, 60)
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
 
     @mock.patch('tap_bing_ads.requests.Session.get')
     def test_timeout_error_stream_report(self, mocked_get, mock_get_selected_fields, mock_get_core_schema, 
@@ -301,9 +291,8 @@ class TestBackoffError(unittest.TestCase):
         try:
             tap_bing_ads.stream_report('dummy_report', '', 'http://test.com', 'dummy_time')
         except Timeout:
-            pass
-        # verify that the request backoffs for 5 times in case of Timeout error
-        self.assertEqual(mocked_get.call_count, 5)
+            # verify that the request backoffs for 5 times in case of Timeout error
+            self.assertEqual(mocked_get.call_count, 5)
 
 # Mock Client 
 class MockedClient():

--- a/tests/unittests/test_request_timeout.py
+++ b/tests/unittests/test_request_timeout.py
@@ -87,7 +87,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
 
     def test_url_error_sync_campaigns(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -107,7 +107,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
 
     def test_url_error_sync_ad_groups(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -127,7 +127,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
 
     def test_url_error_sync_ads(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -147,7 +147,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60) 
 
     @mock.patch("tap_bing_ads.build_report_request")
@@ -170,7 +170,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
 
     def test_url_error_build_report_request(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -190,7 +190,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
 
     def test_url_error_get_type_map(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -210,7 +210,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
 
     def test_url_error_get_report_schema(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -230,7 +230,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
 
     async def test_url_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
@@ -250,7 +250,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
 
     @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
@@ -276,7 +276,7 @@ class TestBackoffError(unittest.TestCase):
         after_time = datetime.datetime.now()
         time_difference = (after_time - before_time).total_seconds()
         # verify the code backed off for 60 seconds
-        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
         self.assertGreaterEqual(time_difference, 60)
 
     @mock.patch('tap_bing_ads.requests.Session.get')

--- a/tests/unittests/test_request_timeout.py
+++ b/tests/unittests/test_request_timeout.py
@@ -1,0 +1,590 @@
+import unittest
+from unittest import mock
+from unittest.case import TestCase
+import tap_bing_ads
+from urllib.error import URLError
+from tap_bing_ads import CustomServiceClient, LOGGER
+import datetime
+    
+class MockClient():
+    '''Mocked ServiceClient class and it's method to pass the test case'''
+    def __init__(self, error):
+        self.error = error
+        self.count = 0
+
+    def GetCampaignsByAccountId(self, AccountId, CampaignType):
+        self.count = self.count + 1
+        raise self.error
+
+    def GetAdGroupsByCampaignId(self, CampaignId):
+        self.count = self.count + 1
+        raise self.error
+
+    def GetAdsByAdGroupId(self, AdGroupId, AdTypes):
+        self.count = self.count + 1
+        raise self.error
+
+    def PollGenerateReport(self):
+        self.count = self.count + 1
+        raise self.error
+
+    def SubmitGenerateReport(self, report_request):
+        self.count = self.count + 1
+        raise self.error
+
+    def PollGenerateReport(self, request_id):
+        self.count = self.count + 1
+        raise self.error
+
+    @property
+    def factory(self):
+        self.count = self.count + 1
+        raise self.error
+
+    @property
+    def soap_client(self):
+        self.count = self.count + 1
+        raise self.error
+
+    @property
+    def call_count(self):
+        return self.count
+
+@mock.patch("tap_bing_ads.filter_selected_fields_many", return_value = '')
+@mock.patch("singer.write_records", return_value = '')
+@mock.patch("singer.metrics", return_value = '')
+@mock.patch("singer.write_bookmark", return_value = '')
+@mock.patch("singer.write_state", return_value = '')
+@mock.patch("tap_bing_ads.sobject_to_dict", return_value = '')
+@mock.patch("singer.get_bookmark", return_value = {'b1': 'b1'})
+@mock.patch("singer.write_schema", return_value = '')
+@mock.patch("tap_bing_ads.get_core_schema", return_value = '')
+@mock.patch("tap_bing_ads.get_selected_fields", return_value = '')
+class TestBackoffError(unittest.TestCase):
+    '''
+    Test that backoff logic works properly. Mocked some common method to test the backoff including
+    filter_selected_fields_many, write_records , metrics, write_bookmark, write_state, sobject_to_dict,
+    get_bookmark, write_schema, get_core_schema, get_selected_fields, time.sleep.
+    '''
+    @mock.patch("tap_bing_ads.create_sdk_client", return_value = '')
+    @mock.patch("tap_bing_ads.CustomServiceClient")
+    def test_url_error_get_account(self, mock_get_account, mock_create_sdk_client,
+                                                    mock_get_selected_fields, mock_get_core_schema,
+                                                    mock_write_schema, mock_get_bookmark,
+                                                    mock_sobject_to_dict, mock_write_state,
+                                                    mock_write_bookmark, mock_metrics, mock_write_records,
+                                                    mock_filter_selected_fields_many):
+        '''
+        Test that tap retry on the url timeout error for 60 seconds.
+        '''
+        mock_get_account.side_effect = URLError('_ssl.c:1059: The handshake operation timed out')
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.sync_accounts_stream(['i1'], {})
+        except URLError:
+            pass
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
+
+    @mock.patch("tap_bing_ads.create_sdk_client", return_value = '')
+    @mock.patch("tap_bing_ads.CustomServiceClient")
+    @mock.patch("time.sleep")
+    def test_url_error_no_timeout_get_account(self, mock_sleep, mock_get_account, mock_create_sdk_client,
+                                                    mock_get_selected_fields, mock_get_core_schema,
+                                                    mock_write_schema, mock_get_bookmark,
+                                                    mock_sobject_to_dict, mock_write_state,
+                                                    mock_write_bookmark, mock_metrics, mock_write_records,
+                                                    mock_filter_selected_fields_many):
+        '''
+        Test that tap does not retry on the url error no timeout.
+        '''
+        mock_get_account.side_effect = URLError('_ssl.c:1059: The handshake operation did not succeed')
+        try:
+            tap_bing_ads.sync_accounts_stream(['i1'], {})
+        except URLError:
+            pass
+        # verify the code did not back off and requested for 1 time
+        self.assertEqual(mock_get_account.call_count, 1)
+
+    def test_url_error_sync_campaigns(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                        mock_write_schema, mock_get_bookmark, 
+                                                        mock_sobject_to_dict, mock_write_state, 
+                                                        mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                        mock_filter_selected_fields_many):
+        '''
+        Test that tap retry on the connection reset error for 1 minute.
+        '''
+        mock_client = MockClient(URLError('_ssl.c:1059: The handshake operation timed out'))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.sync_campaigns(mock_client, '', [])
+        except URLError:
+            pass
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
+
+    @mock.patch("time.sleep")
+    def test_url_error_no_timeout_sync_campaigns(self, mock_sleep, mock_get_selected_fields, mock_get_core_schema, 
+                                                        mock_write_schema, mock_get_bookmark, 
+                                                        mock_sobject_to_dict, mock_write_state, 
+                                                        mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                        mock_filter_selected_fields_many):
+        '''
+        Test that tap does not retry on the url error no timeout.
+        '''
+        mock_client = MockClient(URLError('_ssl.c:1059: The handshake operation did not succeed'))
+        try:
+            tap_bing_ads.sync_campaigns(mock_client, '', [])
+        except URLError:
+            pass
+        # verify the code did not back off and requested for 1 time
+        self.assertEqual(mock_client.call_count, 1)
+
+    def test_url_error_sync_ad_groups(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                        mock_write_schema, mock_get_bookmark, 
+                                                        mock_sobject_to_dict, mock_write_state, 
+                                                        mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                        mock_filter_selected_fields_many):
+        '''
+        Test that tap retry on the connection reset error for 1 minute.
+        '''
+        mock_client = MockClient(URLError('_ssl.c:1059: The handshake operation timed out'))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.sync_ad_groups(mock_client, '', ['dummy_campaign_id'], [])
+        except URLError:
+            pass
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
+
+    @mock.patch("time.sleep")
+    def test_url_error_no_timeout_sync_ad_groups(self, mock_sleep, mock_get_selected_fields, mock_get_core_schema, 
+                                                        mock_write_schema, mock_get_bookmark, 
+                                                        mock_sobject_to_dict, mock_write_state, 
+                                                        mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                        mock_filter_selected_fields_many):
+        '''
+        Test that tap does not retry on the url error no timeout.
+        '''
+        mock_client = MockClient(URLError('_ssl.c:1059: The handshake operation did not succeed'))
+        try:
+            tap_bing_ads.sync_ad_groups(mock_client, '', ['dummy_campaign_id'], [])
+        except URLError:
+            pass
+        # verify the code does not back off and requested for 1 time
+        self.assertEqual(mock_client.call_count, 1)
+
+    def test_url_error_sync_ads(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                mock_write_schema, mock_get_bookmark, 
+                                                mock_sobject_to_dict, mock_write_state, 
+                                                mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                mock_filter_selected_fields_many):
+        '''
+        Test that tap retry on the connection reset error for 1 minute.
+        '''
+        mock_client = MockClient(URLError('_ssl.c:1059: The handshake operation timed out'))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.sync_ads(mock_client, ['dummy_stream'], ['dummy_ad_id'])
+        except URLError:
+            pass
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
+
+    @mock.patch("time.sleep")
+    def test_url_error_no_timeout_sync_ads(self, mock_sleep, mock_get_selected_fields, mock_get_core_schema, 
+                                                mock_write_schema, mock_get_bookmark, 
+                                                mock_sobject_to_dict, mock_write_state, 
+                                                mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                mock_filter_selected_fields_many):
+        '''
+        Test that tap does not retry on the url error no timeout.
+        '''
+        mock_client = MockClient(URLError('_ssl.c:1059: The handshake operation did not succeed'))
+        try:
+            tap_bing_ads.sync_ads(mock_client, ['dummy_stream'], ['dummy_ad_id'])
+        except URLError:
+            pass
+        # verify the code does not back off and requested for 1 time
+        self.assertEqual(mock_client.call_count, 1)    
+
+    @mock.patch("tap_bing_ads.build_report_request")
+    def test_url_error_get_report_request_id(self, mock_build_report_request, 
+                                                           mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many):
+        '''
+        Test that tap retry on the connection reset error for 1 minute.
+        '''
+        mock_client = MockClient(URLError('_ssl.c:1059: The handshake operation timed out'))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.get_report_request_id(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date', 'dummy_start_key',
+                                                force_refresh = True)
+        except URLError:
+            pass
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
+
+    @mock.patch("tap_bing_ads.build_report_request")
+    @mock.patch("time.sleep")
+    def test_url_error_no_timeout_get_report_request_id(self, mock_sleep, mock_build_report_request, 
+                                                           mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many):
+        '''
+        Test that tap does not retry on the url error no timeout.
+        '''
+        mock_client = MockClient(URLError('_ssl.c:1059: The handshake operation did not succeed'))
+        try:
+            tap_bing_ads.get_report_request_id(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date', 'dummy_start_key',
+                                                force_refresh = True)
+        except URLError:
+            pass
+        # verify the code did not back off and requested for 1 time
+        self.assertEqual(mock_client.call_count, 1)
+
+    def test_url_error_build_report_request(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many):
+        '''
+        Test that tap retry on the connection reset error for 1 minute.
+        '''
+        mock_client = MockClient(URLError('_ssl.c:1059: The handshake operation timed out'))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.build_report_request(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date')
+        except URLError:
+            pass
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
+
+    @mock.patch("time.sleep")
+    def test_url_error_no_timeout_build_report_request(self, mock_sleep, mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many):
+        '''
+        Test that tap does not on the url no timeout error.
+        '''
+        mock_client = MockClient(URLError('_ssl.c:1059: The handshake operation did not succeed'))
+        try:
+            tap_bing_ads.build_report_request(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date')
+        except URLError:
+            pass
+        # verify the code did not back off and requested for 1 time
+        self.assertEqual(mock_client.call_count, 1)    
+
+    def test_url_error_get_type_map(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                    mock_write_schema, mock_get_bookmark, 
+                                                    mock_sobject_to_dict, mock_write_state, 
+                                                    mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                    mock_filter_selected_fields_many):
+        '''
+        Test that tap retry on the connection reset error for 1 minute.
+        '''
+        mock_client = MockClient(URLError('_ssl.c:1059: The handshake operation timed out'))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.get_type_map(mock_client)
+        except URLError:
+            pass
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
+
+    @mock.patch("time.sleep")
+    def test_url_no_timeout_error_get_type_map(self, mock_sleep, mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many):
+        '''
+        Test that tap does not retry on the url no timeout error.
+        '''
+        mock_client = MockClient(URLError('_ssl.c:1059: The handshake operation did not succeed'))
+        try:
+            tap_bing_ads.get_type_map(mock_client)
+        except URLError:
+            pass
+        # verify the code did not back off and requested for 1 time
+        self.assertEqual(mock_client.call_count, 1)
+
+    def test_url_error_get_report_schema(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                    mock_write_schema, mock_get_bookmark, 
+                                                    mock_sobject_to_dict, mock_write_state, 
+                                                    mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                    mock_filter_selected_fields_many):
+        '''
+        Test that tap retry on the connection reset error for 1 minute.
+        '''
+        mock_client = MockClient(URLError('_ssl.c:1059: The handshake operation timed out'))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.get_report_schema(mock_client, '')
+        except URLError:
+            pass
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
+
+    @mock.patch("time.sleep")
+    def test_url_no_timeout_error_get_report_schema(self, mock_sleep, mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many):
+        '''
+        Test that tap does not retry on the url no timeout error.
+        '''
+        mock_client = MockClient(URLError('_ssl.c:1059: The handshake operation did not succeed'))
+        try:
+            tap_bing_ads.get_report_schema(mock_client, '')
+        except URLError:
+            pass
+        # verify the code did not back off and requested for 1 time
+        self.assertEqual(mock_client.call_count, 1)
+
+    async def test_url_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many):
+        '''
+        Test that tap retry on the connection reset error for 1 minute.
+        '''
+        mock_client = MockClient(URLError('_ssl.c:1059: The handshake operation timed out'))
+        before_time = datetime.datetime.now()
+        try:
+            await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
+        except URLError:
+            pass
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
+
+    @mock.patch("time.sleep")
+    async def test_url_error_no_timeout_poll_report(self, mock_sleep, mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many):
+        '''
+        Test that tap does not retry on the url error no timeout.
+        '''
+        mock_client = MockClient(URLError('_ssl.c:1059: The handshake operation did not succeed'))
+        try:
+            await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
+        except URLError:
+            pass
+        # verify the code did not back off and requested for 1 time
+        self.assertEqual(mock_client.call_count, 1)
+
+    @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
+    @mock.patch("bingads.OAuthWebAuthCodeGrant.request_oauth_tokens_by_refresh_token")
+    @mock.patch("bingads.AuthorizationData", return_value = '')
+    @mock.patch("tap_bing_ads.CustomServiceClient")
+    def test_url_error_create_sdk_client(self, mock_client, mock_authorization_data, mock_oauth, mock_config,
+                                                        mock_get_selected_fields, mock_get_core_schema, 
+                                                        mock_write_schema, mock_get_bookmark, 
+                                                        mock_sobject_to_dict, mock_write_state, 
+                                                        mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                        mock_filter_selected_fields_many):
+        '''
+        Test that tap retry on the connection reset error for 1 minute.
+        '''
+        mock_oauth.return_value = ''
+        mock_client.side_effect = URLError('_ssl.c:1059: The handshake operation timed out')
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.create_sdk_client('dummy_service', {})
+        except URLError:
+            pass
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
+
+    @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
+    @mock.patch("bingads.OAuthWebAuthCodeGrant.request_oauth_tokens_by_refresh_token")
+    @mock.patch("bingads.AuthorizationData", return_value = '')
+    @mock.patch("tap_bing_ads.CustomServiceClient")
+    @mock.patch("time.sleep")
+    def test_url_error_no_timeout_create_sdk_client(self, mock_sleep, mock_client, mock_authorization_data, mock_oauth, mock_config,
+                                                        mock_get_selected_fields, mock_get_core_schema, 
+                                                        mock_write_schema, mock_get_bookmark, 
+                                                        mock_sobject_to_dict, mock_write_state, 
+                                                        mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                        mock_filter_selected_fields_many):
+        """
+        Test that tap does not retry on the url error no timeout.
+        """
+        mock_oauth.return_value = ''
+        mock_client.side_effect = URLError('_ssl.c:1059: The handshake operation did not succeed')
+        try:
+            tap_bing_ads.create_sdk_client('dummy_service', {})
+        except URLError:
+            pass
+        # verify the code did not back off and requested for 1 time
+        self.assertEqual(mock_oauth.call_count, 1)
+
+    @mock.patch('tap_bing_ads.requests.Session.get')
+    def test_url_error_stream_report(self, mocked_get, mock_get_selected_fields, mock_get_core_schema, 
+                                                        mock_write_schema, mock_get_bookmark, 
+                                                        mock_sobject_to_dict, mock_write_state, 
+                                                        mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                        mock_filter_selected_fields_many):
+        '''
+        Test that tap retry on the url timeout error for 1 minute.
+        '''
+        mocked_get.side_effect = URLError('_ssl.c:1059: The handshake operation timed out')
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.stream_report('dummy_report', '', 'http://test.com', 'dummy_time')
+        except URLError:
+            pass
+        after_time = datetime.datetime.now()
+        time_difference = (after_time - before_time).total_seconds()
+        # verify the code backed off for 60 seconds
+        # time_difference should be greater or equall 60 as some time elapsed while calculating `after_time`
+        self.assertGreaterEqual(time_difference, 60)
+
+    @mock.patch('tap_bing_ads.requests.Session.get')
+    @mock.patch("time.sleep")
+    def test_url_error_no_timeout_stream_report(self, mock_sleep, mocked_get, mock_get_selected_fields, mock_get_core_schema, 
+                                                        mock_write_schema, mock_get_bookmark, 
+                                                        mock_sobject_to_dict, mock_write_state, 
+                                                        mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                        mock_filter_selected_fields_many):
+        '''
+        Test that tap does not retry on the url error no timeout.
+        '''
+        mocked_get.side_effect = URLError('_ssl.c:1059: The handshake operation did not succeed')
+        try:
+            tap_bing_ads.stream_report('dummy_report', '', 'http://test.com', 'dummy_time')
+        except URLError:
+            pass
+        # verify the code did not back off and requested for 1 time
+        self.assertEqual(mocked_get.call_count, 1)
+
+# mock Client 
+class MockedClient():
+    def __init__(self) -> None:
+        pass
+
+# Mock args
+class Args():
+    def __init__(self, config):
+        self.config = config
+        self.discover = False
+        self.properties = False
+        self.catalog = False
+        self.state = False
+
+@mock.patch('tap_bing_ads.utils.parse_args')
+@mock.patch("bingads.OAuthWebAuthCodeGrant.request_oauth_tokens_by_refresh_token")
+@mock.patch("bingads.AuthorizationData", return_value = '')
+@mock.patch("bingads.Client.set_options")
+@mock.patch("tap_bing_ads.CustomServiceClient")
+class TestRequestTimeoutValue(unittest.TestCase):
+    def test_default_value_request_timeout(self, mock_client, mock_set_options, mock_authorization_data, mock_oauth, mocked_args):
+        """ 
+            Unit tests to ensure that request timeout is set based default value
+        """
+        tap_bing_ads.CONFIG = {}
+        config = {"customer_id": "test", "oauth_client_id": "test", "oauth_client_secret": "test", "refresh_token": "test", "developer_token": "test"}
+        args = Args(config)
+        tap_bing_ads.CONFIG.update(args.config)
+        kwargs = {'headers': {}}
+        mock_client.side_effect == MockedClient
+        service_client = CustomServiceClient('CustomerManagementService')
+        service_client.set_options(**kwargs)
+        mock_set_options.assert_called_with(headers={'User-Agent': 'Singer.io Bing Ads Tap'}, timeout=300.0)
+    
+    def test_config_provided_request_timeout(self, mock_client, mock_set_options, mock_authorization_data, mock_oauth, mocked_args):
+        """ 
+            Unit tests to ensure that request timeout is set based on config value
+        """
+        tap_bing_ads.CONFIG = {}
+        config = {"customer_id": "test", "oauth_client_id": "test", "oauth_client_secret": "test", "refresh_token": "test", "developer_token": "test", 'request_timeout': 100}
+        args = Args(config)
+        tap_bing_ads.CONFIG.update(args.config)
+        kwargs = {'headers': {}}
+        mock_client.side_effect == MockedClient
+        service_client = CustomServiceClient('CustomerManagementService')
+        service_client.set_options(**kwargs)
+        mock_set_options.assert_called_with(headers={'User-Agent': 'Singer.io Bing Ads Tap'}, timeout=100.0)
+
+    def test_float_config_provided_request_timeout(self, mock_client, mock_set_options, mock_authorization_data, mock_oauth, mocked_args):
+        """ 
+            Unit tests to ensure that request timeout is set based on config float value
+        """
+        tap_bing_ads.CONFIG = {}
+        config = {"customer_id": "test", "oauth_client_id": "test", "oauth_client_secret": "test", "refresh_token": "test", "developer_token": "test", 'request_timeout': 100.8}
+        args = Args(config)
+        tap_bing_ads.CONFIG.update(args.config)
+        kwargs = {'headers': {}}
+        mock_client.side_effect == MockedClient
+        service_client = CustomServiceClient('CustomerManagementService')
+        service_client.set_options(**kwargs)
+        mock_set_options.assert_called_with(headers={'User-Agent': 'Singer.io Bing Ads Tap'}, timeout=100.8)
+    
+    def test_string_config_provided_request_timeout(self, mock_client, mock_set_options, mock_authorization_data, mock_oauth, mocked_args):
+        """ 
+            Unit tests to ensure that request timeout is set based on config string value
+        """
+        tap_bing_ads.CONFIG = {}
+        config = {"customer_id": "test", "oauth_client_id": "test", "oauth_client_secret": "test", "refresh_token": "test", "developer_token": "test", 'request_timeout': '100'}
+        args = Args(config)
+        tap_bing_ads.CONFIG.update(args.config)
+        kwargs = {'headers': {}}
+        mock_client.side_effect == MockedClient
+        service_client = CustomServiceClient('CustomerManagementService')
+        service_client.set_options(**kwargs)
+        mock_set_options.assert_called_with(headers={'User-Agent': 'Singer.io Bing Ads Tap'}, timeout=100.0)
+    
+    def test_empty_config_provided_request_timeout(self, mock_client, mock_set_options, mock_authorization_data, mock_oauth, mocked_args):
+        """ 
+            Unit tests to ensure that request timeout is set based on default value if empty value is given in config
+        """
+        tap_bing_ads.CONFIG = {}
+        config = {"customer_id": "test", "oauth_client_id": "test", "oauth_client_secret": "test", "refresh_token": "test", "developer_token": "test", 'request_timeout': ''}
+        args = Args(config)
+        tap_bing_ads.CONFIG.update(args.config)
+        kwargs = {'headers': {}}
+        mock_client.side_effect == MockedClient
+        service_client = CustomServiceClient('CustomerManagementService')
+        service_client.set_options(**kwargs)
+        mock_set_options.assert_called_with(headers={'User-Agent': 'Singer.io Bing Ads Tap'}, timeout=300.0)


### PR DESCRIPTION
# Description of change
Implement request timeout with parameter provided in config

# Manual QA steps
- The request backoff for 60 seconds in case it is timed out.
- Error should be thrown in case of retries not successful after all the tries
- Checked the request timeout works for each stream and backoff
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
