### PR TITLE
Tdl 10048 improve bing ads reliability

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,6 @@
 version: 2.1
 orbs:
   slack: circleci/slack@3.4.2
-
 jobs:
   build:
     docker:
@@ -17,6 +16,17 @@ jobs:
             pip install .[dev]
       - add_ssh_keys
       - run:
+          name: 'Unit Tests'
+          command: |
+            source /usr/local/share/virtualenvs/tap-bing-ads/bin/activate
+            pip install nose coverage
+            nosetests --with-coverage --cover-erase --cover-package=tap_bing_ads --cover-html-dir=htmlcov tests/unittests
+            coverage html
+      - store_test_results:
+          path: test_output/report.xml
+      - store_artifacts:
+          path: htmlcov
+      - run:
           name: 'Integration Tests'
           command: |
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
@@ -25,7 +35,6 @@ jobs:
             run-test --tap=tap-bing-ads tests
       - slack/notify-on-failure:
           only_for_branches: master
-
 workflows:
   version: 2
   commit:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,12 @@ jobs:
             python3 -mvenv /usr/local/share/virtualenvs/tap-bing-ads
             source /usr/local/share/virtualenvs/tap-bing-ads/bin/activate
             pip install -U 'pip<19.2' 'setuptools<51.0.0'
-            pip install .[dev]
+            pip install .[test]
+      - run:
+          name: 'pylint'
+          command: |
+            source /usr/local/share/virtualenvs/tap-bing-ads/bin/activate
+            pylint tap_bing_ads -d missing-docstring,line-too-long,invalid-name,super-with-arguments,return-in-init,too-many-arguments,deprecated-method,consider-using-f-string,too-many-lines,unidiomatic-typecheck
       - add_ssh_keys
       - run:
           name: 'Unit Tests'

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,9 @@ setup(
         'backoff==1.8.0',
     ],
     extras_require={
+        'test': [
+            'pylint'
+        ],
         'dev': [
             'ipdb'
         ]

--- a/tap_bing_ads/__init__.py
+++ b/tap_bing_ads/__init__.py
@@ -61,9 +61,11 @@ class InvalidDateRangeEnd(Exception):
     pass
 
 def log_service_call(service_method, account_id):
+    
     def wrapper(*args, **kwargs):
         log_args = list(map(lambda arg: str(arg).replace('\n', '\\n'), args)) + \
                    list(map(lambda kv: '{}={}'.format(*kv), kwargs.items()))
+        # Log the service_method name with it's account ids and in case of any error raise the exception
         LOGGER.info('Calling: {}({}) for account: {}'.format(
             service_method.name,
             ','.join(log_args),
@@ -72,6 +74,7 @@ def log_service_call(service_method, account_id):
             try:
                 return service_method(*args, **kwargs)
             except suds.WebFault as e:
+                #Raise SOAP exception
                 if hasattr(e.fault.detail, 'ApiFaultDetail'):
                     # The Web fault structure is heavily nested. This is to be sure we catch the error we want.
                     operation_errors = e.fault.detail.ApiFaultDetail.OperationErrors
@@ -87,20 +90,27 @@ def log_service_call(service_method, account_id):
     return wrapper
 
 class CustomServiceClient(ServiceClient):
+    # This class calling the methods of the specified Bing Ads service.
     def __init__(self, name, **kwargs):
+        # Initializes a new instance of this ServiceClient class.
         return super().__init__(name, 'v13', **kwargs)
 
     def __getattr__(self, name):
+        # Log and return service call(suds client call) object
         service_method = super(CustomServiceClient, self).__getattr__(name)
         return log_service_call(service_method, self._authorization_data.account_id)
 
     def set_options(self, **kwargs):
+        # Set suds options, these options will be passed to suds.
         self._options = kwargs
+        
         kwargs = ServiceClient._ensemble_header(self.authorization_data, **self._options)
         kwargs['headers']['User-Agent'] = get_user_agent()
+
         self._soap_client.set_options(**kwargs)
 
 def create_sdk_client(service, account_id):
+    # Creates SOAP client with OAuth refresh credentials for services
     LOGGER.info('Creating SOAP client with OAuth refresh credentials for service: %s, account_id %s',
                 service, account_id)
 
@@ -109,14 +119,17 @@ def create_sdk_client(service, account_id):
     else:
         oauth_scope = 'msads.manage'
 
+    # Represents an OAuth authorization object implementing the authorization code grant flow for use in a web application.
     authentication = OAuthWebAuthCodeGrant(
         CONFIG['oauth_client_id'],
         CONFIG['oauth_client_secret'],
         '',
         oauth_scope=oauth_scope) ## redirect URL not needed for refresh token
 
+    # Retrieves OAuth access and refresh tokens from the Microsoft Account authorization service.
     authentication.request_oauth_tokens_by_refresh_token(CONFIG['refresh_token'])
 
+    # Instance require to authenticate with Bing Ads
     authorization_data = AuthorizationData(
         account_id=account_id,
         customer_id=CONFIG['customer_id'],
@@ -126,6 +139,7 @@ def create_sdk_client(service, account_id):
     return CustomServiceClient(service, authorization_data=authorization_data)
 
 def sobject_to_dict(obj):
+    # Convert response of soap to dictionary
     if not hasattr(obj, '__keylist__'):
         return obj
 
@@ -144,6 +158,7 @@ def sobject_to_dict(obj):
     return out
 
 def xml_to_json_type(xml_type):
+    # Convert xml type to json type
     if xml_type == 'boolean':
         return 'boolean'
     if xml_type in ['decimal', 'float', 'double']:
@@ -154,6 +169,7 @@ def xml_to_json_type(xml_type):
     return 'string'
 
 def get_json_schema(element):
+    # Prepare json `type` for schema of streams e.g. "type": ["null","integer"]
     types = []
     _format = None
 
@@ -180,8 +196,10 @@ def get_json_schema(element):
     return schema
 
 def get_array_type(array_type):
+    #Return array type to prepare schema file for streams
+    # e.g "res":{"type": ["null","integer"], "properties": {"id": "type": ["null","integer"]}}
     xml_type = re.match(ARRAY_TYPE_REGEX, array_type).groups()[0]
-    json_type = xml_to_json_type(xml_type)
+    json_type = xml_to_json_type(xml_type) # Convert xml to json type
     if json_type == 'string' and xml_type != 'string':
         # complex type
         items = xml_type # will be filled in fill_in_nested_types
@@ -219,10 +237,11 @@ def get_complex_type_elements(inherited_types, wsdl_type):
         return wsdl_type.rawchildren[0].rawchildren
 
 def wsdl_type_to_schema(inherited_types, wsdl_type):
+    #Prepare schema from wsdl file
     if wsdl_type.root.name == 'simpleType':
-        return get_json_schema(wsdl_type)
+        return get_json_schema(wsdl_type) # Return json schema for simpleType wsdl
 
-    elements = get_complex_type_elements(inherited_types, wsdl_type)
+    elements = get_complex_type_elements(inherited_types, wsdl_type) # Return json schema for complexType(recursive) wsdl
 
     properties = {}
     for element in elements:
@@ -270,6 +289,7 @@ def normalize_abstract_types(inherited_types, type_map):
                 type_map[base_type] = {'anyOf': schemas}
 
 def fill_in_nested_types(type_map, schema):
+    # Prepare nested schema for catalog
     if 'properties' in schema:
         for prop, descriptor in schema['properties'].items():
             schema['properties'][prop] = fill_in_nested_types(type_map, descriptor)
@@ -323,6 +343,7 @@ def get_stream_def(stream_name, schema, stream_metadata=None, pks=None, replicat
     if stream_metadata:
         stream_def['metadata'] = stream_metadata
     else:
+        # Set available inclusion for all keys except replication and primary keys
         stream_def['metadata'] = list(map(
           lambda field: {"metadata": {"inclusion": "available"}, "breadcrumb": ["properties", field]},
           (schema['properties'].keys() - excluded_inclusion_fields)))
@@ -330,6 +351,7 @@ def get_stream_def(stream_name, schema, stream_metadata=None, pks=None, replicat
     return stream_def
 
 def get_core_schema(client, obj):
+    # Get object's schema
     type_map = get_type_map(client)
     return type_map[obj]
 
@@ -339,6 +361,7 @@ def discover_core_objects():
     LOGGER.info('Initializing CustomerManagementService client - Loading WSDL')
     client = CustomServiceClient('CustomerManagementService')
 
+    # Load Account's schemas
     account_schema = get_core_schema(client, 'AdvertiserAccount')
     core_object_streams.append(
         get_stream_def('accounts', account_schema, pks=['Id'], replication_key='LastModifiedTime'))
@@ -346,18 +369,22 @@ def discover_core_objects():
     LOGGER.info('Initializing CampaignManagementService client - Loading WSDL')
     client = CustomServiceClient('CampaignManagementService')
 
+    # Load Campaign's schemas
     campaign_schema = get_core_schema(client, 'Campaign')
     core_object_streams.append(get_stream_def('campaigns', campaign_schema, pks=['Id']))
 
+    # Load AdGroup's schemas
     ad_group_schema = get_core_schema(client, 'AdGroup')
     core_object_streams.append(get_stream_def('ad_groups', ad_group_schema, pks=['Id']))
 
+    # Load Ad's schemas
     ad_schema = get_core_schema(client, 'Ad')
     core_object_streams.append(get_stream_def('ads', ad_schema, pks=['Id']))
 
     return core_object_streams
 
 def get_report_schema(client, report_name):
+    # Load report's schemas
     column_obj_name = '{}Column'.format(report_name)
 
     report_columns_type = None
@@ -370,6 +397,7 @@ def get_report_schema(client, report_name):
 
     properties = {}
     for column in report_columns:
+        # Prepare json `type` for schema of streams e.g. "type": ["null","integer"]
         if column in reports.REPORTING_FIELD_TYPES:
             _type = reports.REPORTING_FIELD_TYPES[column]
         else:
@@ -395,11 +423,13 @@ def get_report_schema(client, report_name):
 
 def metadata_fn(report_name, field, required_fields):
     if field in required_fields:
+        # Set automatic inclusion for all required fields.
         mdata = {"metadata": {"inclusion": "automatic"}, "breadcrumb": ["properties", field]}
     else:
         mdata = {"metadata": {"inclusion": "available"}, "breadcrumb": ["properties", field]}
 
     if EXCLUSIONS.get(report_name):
+        #'fieldExclusions' property that contain fields that cannot be selected with the associated group.
         for group_set in EXCLUSIONS[report_name]:
             if field in group_set['Attributes']:
                 mdata['metadata']['fieldExclusions'] = [
@@ -415,6 +445,7 @@ def metadata_fn(report_name, field, required_fields):
     return mdata
 
 def get_report_metadata(report_name, report_schema):
+    # Load metadata for report streams
     if report_name in reports.REPORT_SPECIFIC_REQUIRED_FIELDS:
         required_fields = (
             reports.REPORT_REQUIRED_FIELDS +
@@ -427,6 +458,7 @@ def get_report_metadata(report_name, report_schema):
         report_schema['properties']))
 
 def discover_reports():
+    # Discover mode for report streams
     report_streams = []
     LOGGER.info('Initializing ReportingService client - Loading WSDL')
     client = CustomServiceClient('ReportingService')
@@ -452,11 +484,12 @@ def test_credentials(account_ids):
     if not account_ids:
         raise Exception('At least one id in account_ids is required to test authentication')
 
-    create_sdk_client('CustomerManagementService', account_ids[0])
+    create_sdk_client('CustomerManagementService', account_ids[0]) # Create bingads sdk client
 
 def do_discover(account_ids):
+    # Discover schemas and dump in STDOUT
     LOGGER.info('Testing authentication')
-    test_credentials(account_ids)
+    test_credentials(account_ids)# Test provided credentails
 
     LOGGER.info('Discovering core objects')
     core_object_streams = discover_core_objects()
@@ -468,6 +501,7 @@ def do_discover(account_ids):
 
 
 def check_for_invalid_selections(prop, mdata, invalid_selections):
+    # Check whether fields 'fieldExclusions' selected or not 
     field_exclusions = metadata.get(mdata, ('properties', prop), 'fieldExclusions')
     is_prop_selected = metadata.get(mdata, ('properties', prop), 'selected')
     if field_exclusions and is_prop_selected:
@@ -482,6 +516,7 @@ def check_for_invalid_selections(prop, mdata, invalid_selections):
 
 
 def get_selected_fields(catalog_item, exclude=None):
+    # Get selected fields only
     if not catalog_item.metadata:
         return None
 
@@ -499,11 +534,13 @@ def get_selected_fields(catalog_item, exclude=None):
             metadata.get(mdata, ('properties', prop), 'selected') is True):
             selected_fields.append(prop)
 
+    # Raise Exception if incompatible fields are selected
     if any(invalid_selections):
         raise Exception("Invalid selections for field(s) - {{ FieldName: [IncompatibleFields] }}:\n{}".format(json.dumps(invalid_selections, indent=4)))
     return selected_fields
 
 def filter_selected_fields(selected_fields, obj):
+    # Return only selected fields 
     if selected_fields:
         return {key:value for key, value in obj.items() if key in selected_fields}
     return obj
@@ -523,7 +560,9 @@ def sync_accounts_stream(account_ids, catalog_item):
     singer.write_schema('accounts', account_schema, ['Id'])
 
     for account_id in account_ids:
+        # Loop over the multiple account_ids
         client = create_sdk_client('CustomerManagementService', account_id)
+        # Get account data
         response = client.GetAccount(AccountId=account_id)
         accounts.append(sobject_to_dict(response))
 
@@ -536,6 +575,7 @@ def sync_accounts_stream(account_ids, catalog_item):
     max_accounts_last_modified = max([x['LastModifiedTime'] for x in accounts])
 
     with metrics.record_counter('accounts') as counter:
+        # Write only selected fields
         singer.write_records('accounts', filter_selected_fields_many(selected_fields, accounts))
         counter.increment(len(accounts))
 
@@ -618,6 +658,7 @@ def sync_core_objects(account_id, selected_streams):
             sync_ads(client, selected_streams, ad_group_ids)
 
 def type_report_row(row):
+    # Check and convert report's field to valid type
     for field_name, value in row.items():
         value = value.strip()
         if value == '':
@@ -641,6 +682,7 @@ def type_report_row(row):
         row[field_name] = value
 
 async def poll_report(client, account_id, report_name, start_date, end_date, request_id):
+    # Get download_url of generated report
     download_url = None
     with metrics.job_timer('generate_report'):
         for i in range(1, MAX_NUM_REPORT_POLLS + 1):
@@ -684,6 +726,7 @@ def log_retry_attempt(details):
                       max_tries=5,
                       on_backoff=log_retry_attempt)
 def stream_report(stream_name, report_name, url, report_time):
+    # Write stream report with backoff of ConnectionError
     with metrics.http_request_timer('download_report'):
         response = SESSION.get(url, headers={'User-Agent': get_user_agent()})
 
@@ -708,6 +751,7 @@ def stream_report(stream_name, report_name, url, report_time):
                         counter.increment()
 
 def get_report_interval(state_key):
+    # Return start_date and end_date for report interval
     report_max_days = int(CONFIG.get('report_max_days', 30))
     conversion_window = int(CONFIG.get('conversion_window', -30))
 
@@ -715,7 +759,7 @@ def get_report_interval(state_key):
     config_end_date = arrow.get(CONFIG.get('end_date')).floor('day')
 
     bookmark_end_date = singer.get_bookmark(STATE, state_key, 'date')
-    conversion_min_date = arrow.get().floor('day').shift(days=conversion_window)
+    conversion_min_date = arrow.get().floor('day').shift(days=conversion_window) # 30 days before the current date
 
     start_date = None
     if bookmark_end_date:
@@ -724,14 +768,14 @@ def get_report_interval(state_key):
         # Will default to today
         start_date = config_start_date.floor('day')
 
-    start_date = min(start_date, conversion_min_date)
+    start_date = min(start_date, conversion_min_date) # minimum of start_date or conversion_min_date
 
-    end_date = min(config_end_date, arrow.get().floor('day'))
+    end_date = min(config_end_date, arrow.get().floor('day')) # minimum of end_date or current date
 
     return start_date, end_date
 
 async def sync_report(client, account_id, report_stream):
-    report_max_days = int(CONFIG.get('report_max_days', 30))
+    report_max_days = int(CONFIG.get('report_max_days', 30)) # Date window size
 
     state_key = '{}_{}'.format(account_id, report_stream.stream)
 
@@ -770,6 +814,7 @@ async def sync_report_interval(client, account_id, report_stream,
 
     report_time = arrow.get().isoformat()
 
+    # Get request id to retrieve report stream
     request_id = get_report_request_id(client, account_id, report_stream,
                                        report_name, start_date, end_date,
                                        state_key)
@@ -778,6 +823,7 @@ async def sync_report_interval(client, account_id, report_stream,
     singer.write_state(STATE)
 
     try:
+        # Get success status and download url
         success, download_url = await poll_report(client, account_id, report_name,
                                                   start_date, end_date, request_id)
 
@@ -841,6 +887,7 @@ def get_report_request_id(client, account_id, report_stream, report_name,
 
 def build_report_request(client, account_id, report_stream, report_name,
                          start_date, end_date):
+    # Build request for report
     LOGGER.info(
         'Syncing report for account {}: {} - from {} to {}'
         .format(account_id, report_name, start_date, end_date)
@@ -891,6 +938,7 @@ def build_report_request(client, account_id, report_stream, report_name,
     return report_request
 
 async def sync_reports(account_id, catalog):
+    # Sync report stream
     client = create_sdk_client('ReportingService', account_id)
 
     reports_to_sync = filter(lambda x: x.is_selected() and x.stream[-6:] == 'report',
@@ -911,13 +959,16 @@ async def sync_account_data(account_id, catalog, selected_streams):
     }
 
     if len(all_core_streams & set(selected_streams)):
+        # Sync all core objects streams
         LOGGER.info('Syncing core objects')
         sync_core_objects(account_id, selected_streams)
 
     if len(all_report_streams & set(selected_streams)):
+        # Sync all report streams
         LOGGER.info('Syncing reports')
         await sync_reports(account_id, catalog)
 
+# run sync mode
 async def do_sync_all_accounts(account_ids, catalog):
     selected_streams = {}
     for stream in filter(lambda x: x.is_selected(), catalog.streams):
@@ -940,10 +991,10 @@ async def main_impl():
     STATE.update(args.state)
     account_ids = CONFIG['account_ids'].split(",")
 
-    if args.discover:
+    if args.discover: # Discover mode
         do_discover(account_ids)
         LOGGER.info("Discovery complete")
-    elif args.catalog:
+    elif args.catalog: # Sync mode
         await do_sync_all_accounts(account_ids, args.catalog)
         LOGGER.info("Sync Completed")
     else:

--- a/tap_bing_ads/__init__.py
+++ b/tap_bing_ads/__init__.py
@@ -27,6 +27,7 @@ from tap_bing_ads import reports
 from tap_bing_ads.exclusions import EXCLUSIONS
 
 LOGGER = singer.get_logger()
+REQUEST_TIMEOUT = 300
 
 REQUIRED_CONFIG_KEYS = [
     "start_date",
@@ -120,6 +121,15 @@ def log_service_call(service_method, account_id):
 
     return wrapper
 
+def get_request_timeout():
+    request_timeout = CONFIG.get('request_timeout')
+    # if request_timeout is other than 0, "0" or "" then use request_timeout else use default request timeout.
+    if request_timeout and float(request_timeout):
+        request_timeout = float(request_timeout)
+    else: # If value is 0, "0" or "" then set default to 300 seconds.
+        request_timeout = REQUEST_TIMEOUT
+    return request_timeout
+
 class CustomServiceClient(ServiceClient):
     # This class calling the methods of the specified Bing Ads service.
     @bing_ads_error_handling
@@ -138,7 +148,8 @@ class CustomServiceClient(ServiceClient):
 
         kwargs = ServiceClient._ensemble_header(self.authorization_data, **self._options)
         kwargs['headers']['User-Agent'] = get_user_agent()
-
+        # setting the timeout parameter using the set_options which sets timeout in the _soap_client
+        kwargs['timeout'] = get_request_timeout()
         self._soap_client.set_options(**kwargs)
 
 @bing_ads_error_handling
@@ -783,14 +794,17 @@ async def poll_report(client, account_id, report_name, start_date, end_date, req
 def log_retry_attempt(details):
     LOGGER.info('Retrieving report timed out, triggering retry #%d', details.get('tries'))
 
+# retry the request for 5 times when Timeout error occurs
 @backoff.on_exception(backoff.constant,
-                      requests.exceptions.ConnectionError,
+                      (requests.exceptions.Timeout ,requests.exceptions.ConnectionError),
                       max_tries=5,
                       on_backoff=log_retry_attempt)
 def stream_report(stream_name, report_name, url, report_time):
     # Write stream report with backoff of ConnectionError
     with metrics.http_request_timer('download_report'):
-        response = SESSION.get(url, headers={'User-Agent': get_user_agent()})
+        # Set request timeout with config param `request_timeout`.
+        request_timeout = get_request_timeout()
+        response = SESSION.get(url, headers={'User-Agent': get_user_agent()}, timeout=request_timeout)
 
     if response.status_code != 200:
         raise Exception('Non-200 ({}) response downloading report: {}'.format(

--- a/tap_bing_ads/__init__.py
+++ b/tap_bing_ads/__init__.py
@@ -9,6 +9,10 @@ import io
 from datetime import datetime
 from zipfile import ZipFile
 
+import socket
+import ssl
+import functools
+from urllib.error import URLError
 import singer
 from singer import utils, metadata, metrics
 from bingads import AuthorizationData, OAuthWebAuthCodeGrant, ServiceClient
@@ -18,10 +22,6 @@ import stringcase
 import requests
 import arrow
 import backoff
-import socket
-import ssl
-import functools
-from urllib.error import URLError
 
 from tap_bing_ads import reports
 from tap_bing_ads.exclusions import EXCLUSIONS
@@ -61,7 +61,7 @@ ARRAY_TYPE_REGEX = r'ArrayOf([A-Za-z0-9]+)'
 def should_retry_httperror(exception):
     """ Return true if exception is required to retry otherwise return false """
     try:
-        if isinstance(exception, ConnectionError) or isinstance(exception, ssl.SSLError) or isinstance(exception, suds.transport.TransportError) or isinstance(exception, socket.timeout) or type(exception) == URLError:
+        if isinstance(exception, ConnectionError) or isinstance(exception, ssl.SSLError) or isinstance(exception, suds.transport.TransportError) or isinstance(exception, socket.timeout) or type(exception) == URLError: # pylint: disable=consider-merging-isinstance,no-else-return)
             return True
         elif (type(exception) == Exception and exception.args[0][0] == 408) or exception.code == 408:
             # A 408 Request Timeout is an HTTP response status code that indicates the server didn't receive a complete
@@ -95,15 +95,12 @@ class InvalidDateRangeEnd(Exception):
     pass
 
 def log_service_call(service_method, account_id):
-    
-    def wrapper(*args, **kwargs):
-        log_args = list(map(lambda arg: str(arg).replace('\n', '\\n'), args)) + \
-                   list(map(lambda kv: '{}={}'.format(*kv), kwargs.items()))
-        # Log the service_method name with it's account ids and in case of any error raise the exception
-        LOGGER.info('Calling: {}({}) for account: {}'.format(
-            service_method.name,
-            ','.join(log_args),
-            account_id))
+    def wrapper(*args, **kwargs): # pylint: disable=inconsistent-return-statements
+        log_args = list(map(lambda arg: str(arg).replace('\n', '\\n'), args)) + list(map(lambda kv: '{}={}'.format(*kv), kwargs.items()))
+        LOGGER.info('Calling: %s(%s) for account: %s',
+                    service_method.name,
+                    ','.join(log_args),
+                    account_id)
         with metrics.http_request_timer(service_method.name):
             try:
                 return service_method(*args, **kwargs)
@@ -116,7 +113,7 @@ def log_service_call(service_method, account_id):
                                                      if oe.ErrorCode == 'InvalidCustomDateRangeEnd']
                     if any(invalid_date_range_end_errors):
                         raise InvalidDateRangeEnd(invalid_date_range_end_errors) from e
-                    LOGGER.info('Caught exception for account: {}'.format(account_id))
+                    LOGGER.info('Caught exception for account: %s', account_id)
                     raise Exception(operation_errors) from e
                 if hasattr(e.fault.detail, 'AdApiFaultDetail'):
                     raise Exception(e.fault.detail.AdApiFaultDetail.Errors) from e
@@ -137,8 +134,8 @@ class CustomServiceClient(ServiceClient):
 
     def set_options(self, **kwargs):
         # Set suds options, these options will be passed to suds.
-        self._options = kwargs
-        
+        self._options = kwargs # pylint: disable=attribute-defined-outside-init
+
         kwargs = ServiceClient._ensemble_header(self.authorization_data, **self._options)
         kwargs['headers']['User-Agent'] = get_user_agent()
 
@@ -258,7 +255,7 @@ def get_array_type(array_type):
 
 def get_complex_type_elements(inherited_types, wsdl_type):
     ## inherited type
-    if isinstance(wsdl_type.rawchildren[0].rawchildren[0], suds.xsd.sxbasic.Extension):
+    if isinstance(wsdl_type.rawchildren[0].rawchildren[0], suds.xsd.sxbasic.Extension): # pylint: disable=no-else-return
         abstract_base = wsdl_type.rawchildren[0].rawchildren[0].ref[0]
         if abstract_base not in inherited_types:
             inherited_types[abstract_base] = set()
@@ -411,9 +408,9 @@ def discover_core_objects():
     # Load Account's schemas
     account_schema = get_core_schema(client, 'AdvertiserAccount')
     core_object_streams.append(
-        # After new standard metadata changes we are getting Id as primary key only 
-        # while earlier we were getting Id and LastModifiedTime both because of the coding mistake 
-        # but we are writing Id only while writing the schema (func: sync_accounts_stream) in sync mode, 
+        # After new standard metadata changes we are getting Id as primary key only
+        # while earlier we were getting Id and LastModifiedTime both because of the coding mistake
+        # but we are writing Id only while writing the schema (func: sync_accounts_stream) in sync mode,
         # Hence we are keeping ID only in pks.
         get_stream_def('accounts', account_schema, pks=['Id'], replication_keys=['LastModifiedTime']))
 
@@ -553,7 +550,7 @@ def do_discover(account_ids):
 
 
 def check_for_invalid_selections(prop, mdata, invalid_selections):
-    # Check whether fields 'fieldExclusions' selected or not 
+    # Check whether fields 'fieldExclusions' selected or not
     field_exclusions = metadata.get(mdata, ('properties', prop), 'fieldExclusions')
     is_prop_selected = metadata.get(mdata, ('properties', prop), 'selected')
     if field_exclusions and is_prop_selected:
@@ -592,7 +589,7 @@ def get_selected_fields(catalog_item, exclude=None):
     return selected_fields
 
 def filter_selected_fields(selected_fields, obj):
-    # Return only selected fields 
+    # Return only selected fields
     if selected_fields:
         return {key:value for key, value in obj.items() if key in selected_fields}
     return obj
@@ -636,7 +633,7 @@ def sync_accounts_stream(account_ids, catalog_item):
     singer.write_state(STATE)
 
 @bing_ads_error_handling
-def sync_campaigns(client, account_id, selected_streams):
+def sync_campaigns(client, account_id, selected_streams): # pylint: disable=inconsistent-return-statements
     # CampaignType defaults to 'Search', but there are other types of campaigns
     response = client.GetCampaignsByAccountId(AccountId=account_id, CampaignType='Search Shopping DynamicSearchAds')
     response_dict = sobject_to_dict(response)
@@ -664,8 +661,8 @@ def sync_ad_groups(client, account_id, campaign_ids, selected_streams):
             ad_groups = sobject_to_dict(response)['AdGroup']
 
             if 'ad_groups' in selected_streams:
-                LOGGER.info('Syncing AdGroups for Account: {}, Campaign: {}'.format(
-                    account_id, campaign_id))
+                LOGGER.info('Syncing AdGroups for Account: %s, Campaign: %s',
+                    account_id, campaign_id)
                 selected_fields = get_selected_fields(selected_streams['ad_groups'])
                 singer.write_schema('ad_groups', get_core_schema(client, 'AdGroup'), ['Id'])
                 with metrics.record_counter('ad_groups') as counter:
@@ -704,13 +701,13 @@ def sync_ads(client, selected_streams, ad_group_ids):
 def sync_core_objects(account_id, selected_streams):
     client = create_sdk_client('CampaignManagementService', account_id)
 
-    LOGGER.info('Syncing Campaigns for Account: {}'.format(account_id))
+    LOGGER.info('Syncing Campaigns for Account: %s', account_id)
     campaign_ids = sync_campaigns(client, account_id, selected_streams)
 
     if campaign_ids and ('ad_groups' in selected_streams or 'ads' in selected_streams):
         ad_group_ids = sync_ad_groups(client, account_id, campaign_ids, selected_streams)
         if 'ads' in selected_streams:
-            LOGGER.info('Syncing Ads for Account: {}'.format(account_id))
+            LOGGER.info('Syncing Ads for Account: %s', account_id)
             sync_ads(client, selected_streams, ad_group_ids)
 
 def type_report_row(row):
@@ -745,40 +742,39 @@ def generate_poll_report(client, request_id):
         Raise the error directly for all errors except mentioned above errors.
     """
     return client.PollGenerateReport(request_id)
-    
+
 async def poll_report(client, account_id, report_name, start_date, end_date, request_id):
     # Get download_url of generated report
     download_url = None
     with metrics.job_timer('generate_report'):
         for i in range(1, MAX_NUM_REPORT_POLLS + 1):
-            LOGGER.info('Polling report job {}/{} - {} - from {} to {}'.format(
+            LOGGER.info('Polling report job %s/%s - %s - from %s to %s',
                 i,
                 MAX_NUM_REPORT_POLLS,
                 report_name,
                 start_date,
-                end_date))
+                end_date)
             # As in the async method backoff does not work directly we created a separate method to handle it.
             response = generate_poll_report(client, request_id)
             if response.Status == 'Error':
-                LOGGER.warn(
-                        'Error polling {} for account {} with request id {}'
-                        .format(report_name, account_id, request_id))
+                LOGGER.warn('Error polling %s for account %s with request id %s',
+                            report_name, account_id, request_id)
                 return False, None
             if response.Status == 'Success':
                 if response.ReportDownloadUrl:
                     download_url = response.ReportDownloadUrl
                 else:
-                    LOGGER.info('No results for report: {} - from {} to {}'.format(
-                        report_name,
-                        start_date,
-                        end_date))
+                    LOGGER.info('No results for report: %s - from %s to %s',
+                                report_name,
+                                start_date,
+                                end_date)
                 break
 
             if i == MAX_NUM_REPORT_POLLS:
-                LOGGER.info('Generating report timed out: {} - from {} to {}'.format(
-                        report_name,
-                        start_date,
-                        end_date))
+                LOGGER.info('Generating report timed out: %s - from %s to %s',
+                            report_name,
+                            start_date,
+                            end_date)
             else:
                 await asyncio.sleep(REPORT_POLL_SLEEP)
 
@@ -799,7 +795,6 @@ def stream_report(stream_name, report_name, url, report_time):
     if response.status_code != 200:
         raise Exception('Non-200 ({}) response downloading report: {}'.format(
             response.status_code, report_name))
-
     with ZipFile(io.BytesIO(response.content)) as zip_file:
         with zip_file.open(zip_file.namelist()[0]) as binary_file:
             with io.TextIOWrapper(binary_file, encoding='utf-8') as csv_file:
@@ -818,7 +813,7 @@ def stream_report(stream_name, report_name, url, report_time):
 
 def get_report_interval(state_key):
     # Return start_date and end_date for report interval
-    report_max_days = int(CONFIG.get('report_max_days', 30))
+    report_max_days = int(CONFIG.get('report_max_days', 30)) # pylint: disable=unused-variable
     conversion_window = int(CONFIG.get('conversion_window', -30))
 
     config_start_date = arrow.get(CONFIG.get('start_date'))
@@ -847,8 +842,8 @@ async def sync_report(client, account_id, report_stream):
 
     start_date, end_date = get_report_interval(state_key)
 
-    LOGGER.info('Generating {} reports for account {} between {} - {}'.format(
-        report_stream.stream, account_id, start_date, end_date))
+    LOGGER.info('Generating %s reports for account %s between %s - %s',
+        report_stream.stream, account_id, start_date, end_date)
 
     current_start_date = start_date
     while current_start_date <= end_date:
@@ -862,7 +857,7 @@ async def sync_report(client, account_id, report_stream):
                                                  report_stream,
                                                  current_start_date,
                                                  current_end_date)
-        except InvalidDateRangeEnd as ex:
+        except InvalidDateRangeEnd as ex: # pylint: disable=unused-variable
             LOGGER.warn("Bing reported that the requested report date range ended outside of "
                         "their data retention period. Skipping to next range...")
             success = True
@@ -893,7 +888,7 @@ async def sync_report_interval(client, account_id, report_stream,
         success, download_url = await poll_report(client, account_id, report_name,
                                                   start_date, end_date, request_id)
 
-    except Exception as some_error:
+    except Exception as some_error: # pylint: disable=broad-except,unused-variable
         LOGGER.info('The request_id %s for %s is invalid, generating a new one',
                     request_id,
                     state_key)
@@ -907,9 +902,9 @@ async def sync_report_interval(client, account_id, report_stream,
         success, download_url = await poll_report(client, account_id, report_name,
                                                   start_date, end_date, request_id)
 
-    if success and download_url:
-        LOGGER.info('Streaming report: {} for account {} - from {} to {}'
-                    .format(report_name, account_id, start_date, end_date))
+    if success and download_url: # pylint: disable=no-else-return
+        LOGGER.info('Streaming report: %s for account %s - from %s to %s',
+                    report_name, account_id, start_date, end_date)
 
         stream_report(report_stream.stream,
                       report_name,
@@ -920,15 +915,15 @@ async def sync_report_interval(client, account_id, report_stream,
         singer.write_state(STATE)
         return True
     elif success and not download_url:
-        LOGGER.info('No data for report: {} for account {} - from {} to {}'
-                    .format(report_name, account_id, start_date, end_date))
+        LOGGER.info('No data for report: %s for account %s - from %s to %s',
+                    report_name, account_id, start_date, end_date)
         singer.write_bookmark(STATE, state_key, 'request_id', None)
         singer.write_bookmark(STATE, state_key, 'date', end_date.isoformat())
         singer.write_state(STATE)
         return True
     else:
-        LOGGER.info('Unsuccessful request for report: {} for account {} - from {} to {}'
-                    .format(report_name, account_id, start_date, end_date))
+        LOGGER.info('Unsuccessful request for report: %s for account %s - from %s to %s',
+                    report_name, account_id, start_date, end_date)
         singer.write_bookmark(STATE, state_key, 'request_id', None)
         singer.write_state(STATE)
         return False
@@ -937,13 +932,10 @@ async def sync_report_interval(client, account_id, report_stream,
 @bing_ads_error_handling
 def get_report_request_id(client, account_id, report_stream, report_name,
                           start_date, end_date, state_key, force_refresh=False):
-
     saved_request_id = singer.get_bookmark(STATE, state_key, 'request_id')
     if not force_refresh and saved_request_id is not None:
-        LOGGER.info(
-            'Resuming polling for account {}: {}'
-            .format(account_id, report_name)
-        )
+        LOGGER.info('Resuming polling for account %s: %s',
+                    account_id, report_name)
         return saved_request_id
 
     report_request = build_report_request(client, account_id, report_stream,
@@ -955,11 +947,8 @@ def get_report_request_id(client, account_id, report_stream, report_name,
 @bing_ads_error_handling
 def build_report_request(client, account_id, report_stream, report_name,
                          start_date, end_date):
-    # Build request for report
-    LOGGER.info(
-        'Syncing report for account {}: {} - from {} to {}'
-        .format(account_id, report_name, start_date, end_date)
-    )
+    LOGGER.info('Syncing report for account %s: %s - from %s to %s',
+                account_id, report_name, start_date, end_date)
 
     report_request = client.factory.create('{}Request'.format(report_name))
     report_request.Format = 'Csv'

--- a/tap_bing_ads/reports.py
+++ b/tap_bing_ads/reports.py
@@ -27,10 +27,7 @@ REPORT_SPECIFIC_REQUIRED_FIELDS = {
         'AdExtensionId',
         'AdExtensionPropertyValue',
         'AdExtensionType',
-        'AdExtensionTypeId',
-        'Clicks',
-        'Ctr',
-        'Impressions'
+        'AdExtensionTypeId' # removed `Impressions`, `Ctr,`, and `Clicks` from the required fields of `AdExtensionDetailReport`
     ],
     'GoalsAndFunnelsReport': ['Goal'],
     # added required fields for `AgeGenderAudienceReport` as mentioned in the bing-ads docs

--- a/tap_bing_ads/reports.py
+++ b/tap_bing_ads/reports.py
@@ -32,7 +32,14 @@ REPORT_SPECIFIC_REQUIRED_FIELDS = {
         'Ctr',
         'Impressions'
     ],
-    'GoalsAndFunnelsReport': ['Goal']
+    'GoalsAndFunnelsReport': ['Goal'],
+    # added required fields for `AgeGenderAudienceReport` as mentioned in the bing-ads docs
+    'AgeGenderAudienceReport': [
+        'AccountName',
+        'AdGroupName',
+        'AgeGroup',
+        'Gender'
+    ],
 }
 
 ## Any not listed here are strings

--- a/tests/base.py
+++ b/tests/base.py
@@ -117,8 +117,7 @@ class BingAdsBaseTest(unittest.TestCase):
         #               'Impressions', 'Ctr', 'Clicks' shouldn't be automatic
         extension_report = copy.deepcopy(default_report)
         extension_report[self.REQUIRED_KEYS] = {
-            'AdExtensionId', 'AdExtensionPropertyValue', 'AdExtensionType', 'AdExtensionTypeId',
-            'Impressions', 'Ctr', 'Clicks'  # Comment this line to reproduce BUG_SRCE-4578
+            'AdExtensionId', 'AdExtensionPropertyValue', 'AdExtensionType', 'AdExtensionTypeId'
         }
 
         age_gender_report = copy.deepcopy(default_report)

--- a/tests/base.py
+++ b/tests/base.py
@@ -92,7 +92,7 @@ class BingAdsBaseTest(unittest.TestCase):
         default_report = {
             self.PRIMARY_KEYS: set(), # "_sdc_report_datetime" is added by tap
             self.REPLICATION_METHOD: self.INCREMENTAL,
-            self.REPLICATION_KEYS: {"TimePeriod"},
+            self.REPLICATION_KEYS: {"TimePeriod"}, # It used in sync but not mentioned in catalog. Bug: TDL-15816
             self.FOREIGN_KEYS: {"AccountId"}
         }
         accounts_meta = {

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -73,33 +73,43 @@ class DiscoveryTest(BingAdsBaseTest):
                 schema = schema_and_metadata["annotated-schema"]
 
                 # verify the stream level properties are as expected
-                # BUG | https://stitchdata.atlassian.net/browse/SRCE-4315
-                # # verify there is only 1 top level breadcrumb
-                # stream_properties = [item for item in metadata if item.get("breadcrumb") == []]
-                # self.assertTrue(len(stream_properties) == 1,
-                #                 msg="There is NOT only one top level breadcrumb for {}".format(stream) + \
-                #                 "\nstream_properties | {}".format(stream_properties))
+                # verify there is only 1 top level breadcrumb
+                stream_properties = [item for item in metadata if item.get("breadcrumb") == []]
+                self.assertTrue(len(stream_properties) == 1,
+                                msg="There is NOT only one top level breadcrumb for {}".format(stream) + \
+                                "\nstream_properties | {}".format(stream_properties))
 
-                # # verify replication key(s)
-                # self.assertEqual(
-                #     set(stream_properties[0].get(
-                #         "metadata", {self.REPLICATION_KEYS: []}).get(self.REPLICATION_KEYS, [])),
-                #     self.expected_replication_keys()[stream],
-                #     msg="expected replication key {} but actual is {}".format(
-                #         self.expected_replication_keys()[stream],
-                #         set(stream_properties[0].get(
-                #             "metadata", {self.REPLICATION_KEYS: None}).get(
-                #                 self.REPLICATION_KEYS, []))))
+                expected_primary_keys = self.expected_primary_keys()[stream]
+                expected_foreign_keys = self.expected_foreign_keys()[stream]
+                expected_replication_keys = self.expected_replication_keys()[stream]
+                # As there is a discrepancy for replication key in existing tap's catalog, sync mode behavior and documentation
+                # removing replication key "TimePeriod" from each report streams. Bug: TDL-15816
+                if stream.endswith("_report"):
+                    expected_replication_keys = expected_replication_keys - {"TimePeriod"}
+                expected_required_keys = self.expected_required_fields()[stream]
+                expected_automatic_fields = expected_primary_keys | expected_replication_keys \
+                    | expected_foreign_keys | expected_required_keys
 
-                # # verify primary key(s)
-                # self.assertEqual(
-                #     set(stream_properties[0].get(
-                #         "metadata", {self.PRIMARY_KEYS: []}).get(self.PRIMARY_KEYS, [])),
-                #     self.expected_primary_keys()[stream],
-                #     msg="expected primary key {} but actual is {}".format(
-                #         self.expected_primary_keys()[stream],
-                #         set(stream_properties[0].get(
-                #             "metadata", {self.PRIMARY_KEYS: None}).get(self.PRIMARY_KEYS, []))))
+                # verify replication key(s)
+                self.assertEqual(
+                    set(stream_properties[0].get(
+                        "metadata", {self.REPLICATION_KEYS: []}).get(self.REPLICATION_KEYS, [])),
+                    expected_replication_keys,
+                    msg="expected replication key {} but actual is {}".format(
+                        expected_replication_keys,
+                        set(stream_properties[0].get(
+                            "metadata", {self.REPLICATION_KEYS: None}).get(
+                                self.REPLICATION_KEYS, []))))
+
+                # verify primary key(s)
+                self.assertEqual(
+                    set(stream_properties[0].get(
+                        "metadata", {self.PRIMARY_KEYS: []}).get(self.PRIMARY_KEYS, [])),
+                    expected_primary_keys,
+                    msg="expected primary key {} but actual is {}".format(
+                        expected_primary_keys,
+                        set(stream_properties[0].get(
+                            "metadata", {self.PRIMARY_KEYS: None}).get(self.PRIMARY_KEYS, []))))
 
                 # # verify that if there is a replication key we are doing INCREMENTAL otherwise FULL
                 # actual_replication_method = stream_properties[0].get(
@@ -111,7 +121,7 @@ class DiscoveryTest(BingAdsBaseTest):
                 #                     msg="Expected INCREMENTAL replication "
                 #                         "since there is a replication key")
                 # else:
-                #     self.assertTrue(actual_replication_method == self.FULL,
+                #     self.assertTrue(actual_replication_method == self.FULL_TABLE,
                 #                     msg="Expected FULL replication "
                 #                         "since there is no replication key")
 
@@ -124,13 +134,6 @@ class DiscoveryTest(BingAdsBaseTest):
                 #         self.expected_replication_method().get(stream, None)))
 
                 # END OF BUG SRCE-4315
-
-                expected_primary_keys = self.expected_primary_keys()[stream]
-                expected_foreign_keys = self.expected_foreign_keys()[stream]
-                expected_replication_keys = self.expected_replication_keys()[stream]
-                expected_required_keys = self.expected_required_fields()[stream]
-                expected_automatic_fields = expected_primary_keys | expected_replication_keys \
-                    | expected_foreign_keys | expected_required_keys
 
                 # BUG | https://stitchdata.atlassian.net/browse/SRCE-4313
                 #       Uncomment from this point forward to see test failure and address bug

--- a/tests/unittests/test_backoff_error_handling.py
+++ b/tests/unittests/test_backoff_error_handling.py
@@ -1,0 +1,1921 @@
+import unittest
+import socket
+from unittest import mock
+import tap_bing_ads
+from urllib.error import HTTPError, URLError
+import ssl
+from suds.transport import TransportError
+import datetime
+
+class MockClient():
+    '''Mocked ServiceClient class and it's method to pass the test case'''
+    def __init__(self, error):
+        self.error = error
+
+    def GetCampaignsByAccountId(self, AccountId, CampaignType):
+        """ Mocked GetCampaignsByAccountId to test the backoff in sync_campaigns method """
+        raise self.error
+
+    def GetAdGroupsByCampaignId(self, CampaignId):
+        """ Mocked GetAdGroupsByCampaignId to test the backoff in sync_ad_groups method"""
+        raise self.error
+
+    def GetAdsByAdGroupId(self, AdGroupId, AdTypes):
+        """ Mocked GetAdsByAdGroupId test to the backoff in sync_ads method"""
+        raise self.error
+
+    def SubmitGenerateReport(self, report_request):
+        """ Mocked SubmitGenerateReport to test the backoff in get_report_request_id method"""
+        raise self.error
+
+    def PollGenerateReport(self, request_id):
+        """ Mocked PollGenerateReport to test the backoff in poll_report method"""
+        raise self.error
+
+    @property
+    def factory(self):
+        """ Mocked factory to test backoff the in build_report_request method"""
+        raise self.error
+
+    @property
+    def soap_client(self):
+        """ Mocked soap_client to test backoff in get_type_map method"""
+        raise self.error
+
+@mock.patch("tap_bing_ads.filter_selected_fields_many", return_value = '')
+@mock.patch("singer.write_records", return_value = '')
+@mock.patch("singer.metrics", return_value = '')
+@mock.patch("singer.write_bookmark", return_value = '')
+@mock.patch("singer.write_state", return_value = '')
+@mock.patch("tap_bing_ads.sobject_to_dict", return_value = '')
+@mock.patch("singer.get_bookmark", return_value = {'b1': 'b1'})
+@mock.patch("singer.write_schema", return_value = '')
+@mock.patch("tap_bing_ads.get_core_schema", return_value = '')
+@mock.patch("tap_bing_ads.get_selected_fields", return_value = '')
+class TestBackoffError(unittest.TestCase):
+    '''
+    Test that backoff logic works properly. Mocked some common method to test the backoff including
+    filter_selected_fields_many, write_records , metrics, write_bookmark, write_state, sobject_to_dict,
+    get_bookmark, write_schema, get_core_schema, get_selected_fields, time.sleep.
+    '''
+    @mock.patch("tap_bing_ads.create_sdk_client", return_value = '')
+    @mock.patch("tap_bing_ads.CustomServiceClient")
+    def test_connection_reset_error_get_account(self, mock_get_account, mock_create_sdk_client,
+                                                    mock_get_selected_fields, mock_get_core_schema,
+                                                    mock_write_schema, mock_get_bookmark,
+                                                    mock_sobject_to_dict, mock_write_state,
+                                                    mock_write_bookmark, mock_metrics, mock_write_records,
+                                                    mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the connection reset error.
+        '''
+        mock_get_account.side_effect = socket.error(104, 'Connection reset by peer')
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.sync_accounts_stream(['i1'], {})
+        except ConnectionResetError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+        
+    @mock.patch("tap_bing_ads.create_sdk_client", return_value = '')
+    @mock.patch("tap_bing_ads.CustomServiceClient")
+    def test_socket_timeout__error_get_account(self, mock_get_account, mock_create_sdk_client,
+                                                    mock_get_selected_fields, mock_get_core_schema,
+                                                    mock_write_schema, mock_get_bookmark,
+                                                    mock_sobject_to_dict, mock_write_state,
+                                                    mock_write_bookmark, mock_metrics, mock_write_records,
+                                                    mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the socket timeout error.
+        '''
+        mock_get_account.side_effect = socket.timeout()
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.sync_accounts_stream(['i1'], {})
+        except socket.timeout:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+        
+    @mock.patch("tap_bing_ads.create_sdk_client", return_value = '')
+    @mock.patch("tap_bing_ads.CustomServiceClient")
+    def test_http_timeout__error_get_account(self, mock_get_account, mock_create_sdk_client,
+                                                    mock_get_selected_fields, mock_get_core_schema,
+                                                    mock_write_schema, mock_get_bookmark,
+                                                    mock_sobject_to_dict, mock_write_state,
+                                                    mock_write_bookmark, mock_metrics, mock_write_records,
+                                                    mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the http timeout error.
+        '''
+        with open('tests/base.py') as f:
+            mock_get_account.side_effect = HTTPError('url', 408, 'Request Timeout', {}, f)
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.sync_accounts_stream(['i1'], {})
+        except HTTPError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+        
+    @mock.patch("tap_bing_ads.create_sdk_client", return_value = '')
+    @mock.patch("tap_bing_ads.CustomServiceClient")
+    def test_internal_server_error_get_account(self, mock_get_account, mock_create_sdk_client,
+                                                    mock_get_selected_fields, mock_get_core_schema,
+                                                    mock_write_schema, mock_get_bookmark,
+                                                    mock_sobject_to_dict, mock_write_state,
+                                                    mock_write_bookmark, mock_metrics, mock_write_records,
+                                                    mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the 500 internal server error.
+        '''
+        with open('tests/base.py') as f:
+            mock_get_account.side_effect = HTTPError('url', 500, 'Internal Server Error', {}, f)
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.sync_accounts_stream(['i1'], {})
+        except HTTPError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+        
+    @mock.patch("tap_bing_ads.create_sdk_client", return_value = '')
+    @mock.patch("tap_bing_ads.CustomServiceClient")
+    def test_transport_error_get_account(self, mock_get_account, mock_create_sdk_client,
+                                                mock_get_selected_fields, mock_get_core_schema,
+                                                mock_write_schema, mock_get_bookmark,
+                                                mock_sobject_to_dict, mock_write_state, 
+                                                mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the Transport error.
+        '''
+        mock_get_account.side_effect = TransportError('url', 500, 'Internal Server Error')
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.sync_accounts_stream(['i1'], {})
+        except TransportError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+        
+    @mock.patch("tap_bing_ads.create_sdk_client", return_value = '')
+    @mock.patch("tap_bing_ads.CustomServiceClient")
+    def test_400_error_get_account(self, mock_get_account, mock_create_sdk_client, 
+                                        mock_get_selected_fields, mock_get_core_schema, 
+                                        mock_write_schema, mock_get_bookmark, 
+                                        mock_sobject_to_dict, mock_write_state, 
+                                        mock_write_bookmark, mock_metrics, mock_write_records, 
+                                        mock_filter_selected_fields_many):
+        '''
+        Test that tap does not retry on the 400 error.
+        '''
+        with open('tests/base.py') as f:
+            mock_get_account.side_effect = HTTPError('url', 400, 'Bad Request', {}, f)
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.sync_accounts_stream(['i1'], {})
+        except HTTPError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code raise error without backoff
+            # time_difference should be less or equal 1 as it directly raise the error without backoff
+            self.assertGreaterEqual(1, time_difference)
+
+    @mock.patch("tap_bing_ads.create_sdk_client", return_value = '')
+    @mock.patch("tap_bing_ads.CustomServiceClient")
+    def test_url_error_get_account(self, mock_get_account, mock_create_sdk_client, 
+                                        mock_get_selected_fields, mock_get_core_schema, 
+                                        mock_write_schema, mock_get_bookmark, 
+                                        mock_sobject_to_dict, mock_write_state, 
+                                        mock_write_bookmark, mock_metrics, mock_write_records, 
+                                        mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the URLError.
+        '''
+        mock_get_account.side_effect  = URLError("<urlopen error [Errno 104] Connection reset by peer>")
+        
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.sync_accounts_stream(['i1'], {})
+        except URLError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+       
+    @mock.patch("tap_bing_ads.create_sdk_client", return_value = '')
+    @mock.patch("tap_bing_ads.CustomServiceClient")
+    def test_ssl_eof_error_get_account(self, mock_get_account, mock_create_sdk_client,
+                                                           mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the SSLEOFError.
+        '''
+        with open('tests/base.py') as f:
+            mock_get_account.side_effect = ssl.SSLEOFError('EOF occurred in violation of protocol')
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.sync_accounts_stream(['i1'], {})
+        except ssl.SSLEOFError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+
+    @mock.patch("tap_bing_ads.create_sdk_client", return_value = '')
+    @mock.patch("tap_bing_ads.CustomServiceClient")
+    def test_exception_408_error_get_account(self, mock_get_account, mock_create_sdk_client,
+                                                           mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the Exception with error code 408.
+        '''
+        mock_get_account.side_effect = Exception((408, 'Request Timeout'))
+
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.sync_accounts_stream(['i1'], {})
+        except Exception:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+        
+    def test_connection_reset_error_sync_campaigns(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                        mock_write_schema, mock_get_bookmark, 
+                                                        mock_sobject_to_dict, mock_write_state, 
+                                                        mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                        mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the connection reset error.
+        '''
+        mock_client = MockClient(socket.error(104, 'Connection reset by peer'))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.sync_campaigns(mock_client, '', [])
+        except ConnectionResetError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+        
+    def test_socket_timeout_error_sync_campaigns(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                        mock_write_schema, mock_get_bookmark, 
+                                                        mock_sobject_to_dict, mock_write_state, 
+                                                        mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                        mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the socket timeout error.
+        '''
+        mock_client = MockClient(socket.timeout())
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.sync_campaigns(mock_client, '', [])
+        except socket.timeout:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+        
+    def test_http_timeout_error_sync_campaigns(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                    mock_write_schema, mock_get_bookmark, 
+                                                    mock_sobject_to_dict, mock_write_state, 
+                                                    mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                    mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the http timeout error.
+        '''
+        with open('tests/base.py') as f:
+            mock_client = MockClient(HTTPError('url', 408, 'Request Timeout', {}, f))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.sync_campaigns(mock_client, '', [])
+        except HTTPError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+        
+    def test_internal_server_error_sync_campaigns(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                        mock_write_schema, mock_get_bookmark, 
+                                                        mock_sobject_to_dict, mock_write_state, 
+                                                        mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                        mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the 500 internal server error.
+        '''
+        with open('tests/base.py') as f:
+            mock_client = MockClient(HTTPError('url', 500, 'Internal Server Error', {}, f))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.sync_campaigns(mock_client, '', [])
+        except HTTPError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+        
+    def test_transport_server_error_sync_campaigns(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                        mock_write_schema, mock_get_bookmark, 
+                                                        mock_sobject_to_dict, mock_write_state, 
+                                                        mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                        mock_filter_selected_fields_many):
+        mock_client = MockClient(TransportError('url', 500, 'Internal Server Error'))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.sync_campaigns(mock_client, '', [])
+        except TransportError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+        
+    def test_400_error_sync_campaigns(self, mock_get_selected_fields, mock_get_core_schema, 
+                                            mock_write_schema, mock_get_bookmark, 
+                                            mock_sobject_to_dict, mock_write_state, 
+                                            mock_write_bookmark, mock_metrics, mock_write_records, 
+                                            mock_filter_selected_fields_many):
+        '''
+        Test that tap does not retry on the 400 error.
+        '''
+        with open('tests/base.py') as f:
+            mock_client = MockClient(HTTPError('url', 400, 'Bad Request', {}, f))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.sync_campaigns(mock_client, '', [])
+        except HTTPError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code raise error without backoff
+            # time_difference should be less or equal 1 as it directly raise the error without backoff
+            self.assertGreaterEqual(1, time_difference)
+    
+    def test_url_error_sync_campaigns(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                        mock_write_schema, mock_get_bookmark, 
+                                                        mock_sobject_to_dict, mock_write_state, 
+                                                        mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                        mock_filter_selected_fields_many):
+        mock_client = MockClient(URLError("<urlopen error [Errno 104] Connection reset by peer>"))
+        
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.sync_campaigns(mock_client, '', [])
+        except URLError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+
+    def test_ssl_eof_error_sync_campaigns(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                mock_write_schema, mock_get_bookmark, 
+                                                mock_sobject_to_dict, mock_write_state, 
+                                                mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the SSLEOFError.
+        '''
+        with open('tests/base.py') as f:
+            mock_client = MockClient(ssl.SSLEOFError('EOF occurred in violation of protocol'))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.sync_campaigns(mock_client, '', [])
+        except ssl.SSLEOFError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+
+    def test_exception_408_sync_campaigns(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                        mock_write_schema, mock_get_bookmark, 
+                                                        mock_sobject_to_dict, mock_write_state, 
+                                                        mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                        mock_filter_selected_fields_many):
+        mock_client = MockClient(Exception((408, 'Request Timeout')))
+        
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.sync_campaigns(mock_client, '', [])
+        except Exception:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+
+    def test_connection_reset_error_sync_ad_groups(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                        mock_write_schema, mock_get_bookmark, 
+                                                        mock_sobject_to_dict, mock_write_state, 
+                                                        mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                        mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the connection reset error.
+        '''
+        mock_client = MockClient(socket.error(104, 'Connection reset by peer'))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.sync_ad_groups(mock_client, '', ['dummy_campaign_id'], [])
+        except ConnectionResetError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+        
+    def test_socket_timeout_error_sync_ad_groups(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                        mock_write_schema, mock_get_bookmark, 
+                                                        mock_sobject_to_dict, mock_write_state, 
+                                                        mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                        mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the socket timeout error.
+        '''
+        mock_client = MockClient(socket.timeout())
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.sync_ad_groups(mock_client, '', ['dummy_campaign_id'], [])
+        except socket.timeout:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+        
+    def test_http_timeout_error_sync_ad_groups(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                    mock_write_schema, mock_get_bookmark, 
+                                                    mock_sobject_to_dict, mock_write_state, 
+                                                    mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                    mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the http timeout error.
+        '''
+        with open('tests/base.py') as f:
+            mock_client = MockClient(HTTPError('url', 408, 'Request Timeout', {}, f))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.sync_ad_groups(mock_client, '', ['dummy_campaign_id'], [])
+        except HTTPError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+        
+    def test_internal_server_error_sync_ad_groups(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                        mock_write_schema, mock_get_bookmark, 
+                                                        mock_sobject_to_dict, mock_write_state, 
+                                                        mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                        mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the 500 internal server error.
+        '''
+        with open('tests/base.py') as f:
+            mock_client = MockClient(HTTPError('url', 500, 'Internal Server Error', {}, f))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.sync_ad_groups(mock_client, '', ['dummy_campaign_id'], [])
+        except HTTPError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+        
+    def test_transport_error_sync_ad_groups(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                        mock_write_schema, mock_get_bookmark, 
+                                                        mock_sobject_to_dict, mock_write_state, 
+                                                        mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                        mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the Transport error.
+        '''
+        mock_client = MockClient(TransportError('url', 500, 'Internal Server Error'))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.sync_ad_groups(mock_client, '', ['dummy_campaign_id'], [])
+        except TransportError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+        
+    def test_400_error_sync_ad_groups(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                        mock_write_schema, mock_get_bookmark, 
+                                                        mock_sobject_to_dict, mock_write_state, 
+                                                        mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                        mock_filter_selected_fields_many):
+        '''
+        Test that tap does not retry on the 400 error.
+        '''
+        with open('tests/base.py') as f:
+            mock_client = MockClient(HTTPError('url', 400, 'Bad Request', {}, f))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.sync_ad_groups(mock_client, '', ['dummy_campaign_id'], [])
+        except HTTPError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code raise error without backoff
+            # time_difference should be less or equal 1 as it directly raise the error without backoff
+            self.assertGreaterEqual(1, time_difference)
+
+    def test_url_error_sync_ad_groups(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                        mock_write_schema, mock_get_bookmark, 
+                                                        mock_sobject_to_dict, mock_write_state, 
+                                                        mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                        mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the URLError.
+        '''
+        mock_client = MockClient(URLError("<urlopen error [Errno 104] Connection reset by peer>"))
+        
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.sync_ad_groups(mock_client, '', ['dummy_campaign_id'], [])
+        except URLError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+ 
+    def test_ssl_eof_error_sync_ad_groups(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                mock_write_schema, mock_get_bookmark, 
+                                                mock_sobject_to_dict, mock_write_state, 
+                                                mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the SSLEOFError.
+        '''
+        with open('tests/base.py') as f:
+            mock_client = MockClient(ssl.SSLEOFError('EOF occurred in violation of protocol'))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.sync_ad_groups(mock_client, '', ['dummy_campaign_id'], [])
+        except ssl.SSLEOFError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)        
+
+    def test_exception_408_sync_ad_groups(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                        mock_write_schema, mock_get_bookmark, 
+                                                        mock_sobject_to_dict, mock_write_state, 
+                                                        mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                        mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the Exception with error code 408.
+        '''
+        mock_client = MockClient(Exception((408, 'Request Timeout')))
+        
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.sync_ad_groups(mock_client, '', ['dummy_campaign_id'], [])
+        except Exception:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+
+    def test_connection_reset_error_sync_ads(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                mock_write_schema, mock_get_bookmark, 
+                                                mock_sobject_to_dict, mock_write_state, 
+                                                mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the connection reset error.
+        '''
+        mock_client = MockClient(socket.error(104, 'Connection reset by peer'))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.sync_ads(mock_client, ['dummy_stream'], ['dummy_ad_id'])
+        except ConnectionResetError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+        
+    def test_socket_timeout_error_sync_ads(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                mock_write_schema, mock_get_bookmark, 
+                                                mock_sobject_to_dict, mock_write_state, 
+                                                mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the socket timeout error.
+        '''
+        mock_client = MockClient(socket.timeout())
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.sync_ads(mock_client, ['dummy_stream'], ['dummy_ad_id'])
+        except socket.timeout:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+        
+    def test_http_timeout_error_sync_ads(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                mock_write_schema, mock_get_bookmark, 
+                                                mock_sobject_to_dict, mock_write_state, 
+                                                mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                smock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the http timeout error.
+        '''
+        with open('tests/base.py') as f:
+            mock_client = MockClient(HTTPError('url', 408, 'Request Timeout', {}, f))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.sync_ads(mock_client, ['dummy_stream'], ['dummy_ad_id'])
+        except HTTPError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+        
+    def test_internal_server_error_sync_ads(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                mock_write_schema, mock_get_bookmark, 
+                                                mock_sobject_to_dict, mock_write_state, 
+                                                mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the 500 internal server error.
+        '''
+        with open('tests/base.py') as f:
+            mock_client = MockClient(HTTPError('url', 500, 'Internal Server Error', {}, f))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.sync_ads(mock_client, ['dummy_stream'], ['dummy_ad_id'])
+        except HTTPError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)        
+
+    def test_transport_error_sync_ads(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                mock_write_schema, mock_get_bookmark, 
+                                                mock_sobject_to_dict, mock_write_state, 
+                                                mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the Transport error.
+        '''
+        mock_client = MockClient(TransportError('url', 500, 'Internal Server Error'))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.sync_ads(mock_client, ['dummy_stream'], ['dummy_ad_id'])
+        except TransportError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60) 
+
+    def test_400_error_sync_ads(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                mock_write_schema, mock_get_bookmark, 
+                                                mock_sobject_to_dict, mock_write_state, 
+                                                mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                mock_filter_selected_fields_many):
+        '''
+        Test that tap does not retry on the 400 error.
+        '''
+        with open('tests/base.py') as f:
+            mock_client = MockClient(HTTPError('url', 400, 'Bad Request', {}, f))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.sync_ads(mock_client, ['dummy_stream'], ['dummy_ad_id'])
+        except HTTPError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code raise error without backoff
+            # time_difference should be less or equal 1 as it directly raise the error without backoff
+            self.assertGreaterEqual(1, time_difference)
+
+    def test_url_error_sync_ads(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                mock_write_schema, mock_get_bookmark, 
+                                                mock_sobject_to_dict, mock_write_state, 
+                                                mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the URLError.
+        '''
+        mock_client = MockClient(URLError("<urlopen error [Errno 104] Connection reset by peer>"))
+        
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.sync_ads(mock_client, ['dummy_stream'], ['dummy_ad_id'])
+        except URLError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60) 
+
+    def test_ssl_eof_error_sync_ads(self, mock_get_selected_fields, mock_get_core_schema, 
+                                        mock_write_schema, mock_get_bookmark, 
+                                        mock_sobject_to_dict, mock_write_state, 
+                                        mock_write_bookmark, mock_metrics, mock_write_records, 
+                                        mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the SSLEOFError.
+        '''
+        with open('tests/base.py') as f:
+            mock_client = MockClient(ssl.SSLEOFError('EOF occurred in violation of protocol'))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.sync_ads(mock_client, ['dummy_stream'], ['dummy_ad_id'])
+        except ssl.SSLEOFError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)  
+
+    def test_exception_408_sync_ads(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                mock_write_schema, mock_get_bookmark, 
+                                                mock_sobject_to_dict, mock_write_state, 
+                                                mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the Exception with error code 408.
+        '''
+        mock_client = MockClient(Exception((408, 'Request Timeout')))
+        
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.sync_ads(mock_client, ['dummy_stream'], ['dummy_ad_id'])
+        except Exception:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60) 
+
+    @mock.patch("tap_bing_ads.build_report_request")
+    def test_connection_reset_error_get_report_request_id(self, mock_build_report_request, 
+                                                           mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the connection reset error.
+        '''
+        mock_client = MockClient(socket.error(104, 'Connection reset by peer'))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.get_report_request_id(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date', 'dummy_start_key',
+                                                force_refresh = True)
+        except ConnectionResetError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+        
+    @mock.patch("tap_bing_ads.build_report_request")
+    def test_socket_timeout_error_get_report_request_id(self, mock_build_report_request, 
+                                                           mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many):
+        mock_client = MockClient(socket.timeout())
+        before_time = datetime.datetime.now()
+        try:
+           tap_bing_ads.get_report_request_id(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date', 'dummy_start_key', 
+                                              force_refresh = True)
+        except socket.timeout:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+        
+    @mock.patch("tap_bing_ads.build_report_request")
+    def test_http_timeout_error_get_report_request_id(self, mock_build_report_request, 
+                                                           mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the http timeout error.
+        '''
+        with open('tests/base.py') as f:
+            mock_client = MockClient(HTTPError('url', 408, 'Request Timeout', {}, f))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.get_report_request_id(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date', 'dummy_start_key',
+                                               force_refresh = True)
+        except HTTPError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+     
+    @mock.patch("tap_bing_ads.build_report_request")   
+    def test_internal_server_error_get_report_request_id(self, mock_build_report_request,
+                                                           mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the 500 internal server error.
+        '''
+        with open('tests/base.py') as f:
+            mock_client = MockClient(HTTPError('url', 500, 'Internal Server Error', {}, f))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.get_report_request_id(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date', 'dummy_start_key',
+                                               force_refresh = True)
+        except HTTPError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+
+    @mock.patch("tap_bing_ads.build_report_request")   
+    def test_transport_error_get_report_request_id(self, mock_build_report_request,
+                                                           mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the Transport error.
+        '''
+        mock_client = MockClient(TransportError('url', 500, 'Internal Server Error'))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.get_report_request_id(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date', 'dummy_start_key',
+                                               force_refresh = True)
+        except TransportError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+        
+    @mock.patch("tap_bing_ads.build_report_request")   
+    def test_400_error_get_report_request_id(self, mock_build_report_request,
+                                                           mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many):
+        '''
+        Test that tap does not retry on the 400 error.
+        '''
+        with open('tests/base.py') as f:
+            mock_client = MockClient(HTTPError('url', 400, 'Bad Request', {}, f))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.get_report_request_id(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date', 'dummy_start_key',
+                                               force_refresh = True)
+        except HTTPError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code raise error without backoff
+            # time_difference should be less or equal 1 as it directly raise the error without backoff
+            self.assertGreaterEqual(1, time_difference)
+
+    @mock.patch("tap_bing_ads.build_report_request")   
+    def test_url_error_get_report_request_id(self, mock_build_report_request,
+                                                           mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the URLError.
+        '''
+        mock_client = MockClient(URLError("<urlopen error [Errno 104] Connection reset by peer>"))
+        
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.get_report_request_id(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date', 'dummy_start_key',
+                                               force_refresh = True)
+        except URLError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+    
+    @mock.patch("tap_bing_ads.build_report_request")   
+    def test_ssl_eof_error_get_report_request_id(self, mock_build_report_request,
+                                                           mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the SSLEOFError.
+        '''
+        with open('tests/base.py') as f:
+            mock_client = MockClient(ssl.SSLEOFError('EOF occurred in violation of protocol'))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.get_report_request_id(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date', 'dummy_start_key',
+                                               force_refresh = True)
+        except ssl.SSLEOFError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+
+    @mock.patch("tap_bing_ads.build_report_request")   
+    def test_url_error_get_report_request_id(self, mock_build_report_request,
+                                                           mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the Exception with error code 408.
+        '''
+        mock_client = MockClient(Exception((408, 'Request Timeout')))
+        
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.get_report_request_id(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date', 'dummy_start_key',
+                                               force_refresh = True)
+        except Exception:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+
+    def test_connection_reset_error_build_report_request(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the connection reset error.
+        '''
+        mock_client = MockClient(socket.error(104, 'Connection reset by peer'))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.build_report_request(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date')
+        except ConnectionResetError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+        
+    def test_socket_timeout_error_build_report_request(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the socket timeout error.
+        '''
+        mock_client = MockClient(socket.timeout())
+        before_time = datetime.datetime.now()
+        try:
+           tap_bing_ads.build_report_request(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date')
+        except socket.timeout:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+        
+    def test_http_timeout_error_build_report_request(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the http timeout error.
+        '''
+        with open('tests/base.py') as f:
+            mock_client = MockClient(HTTPError('url', 408, 'Request Timeout', {}, f))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.build_report_request(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date')
+        except HTTPError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+     
+    def test_internal_server_error_build_report_request(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the 500 internal server error.
+        '''
+        with open('tests/base.py') as f:
+            mock_client = MockClient(HTTPError('url', 500, 'Internal Server Error', {}, f))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.build_report_request(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date')
+        except HTTPError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+        
+    def test_transport_error_build_report_request(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the Transport error.
+        '''
+        mock_client = MockClient(TransportError('url', 500, 'Internal Server Error'))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.build_report_request(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date')
+        except TransportError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+        
+    def test_400_error_build_report_request(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many):
+        '''
+        Test that tap does not retry on the 400 error.
+        '''
+        with open('tests/base.py') as f:
+            mock_client = MockClient(HTTPError('url', 400, 'Bad Request', {}, f))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.build_report_request(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date')
+        except HTTPError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code raise error without backoff
+            # time_difference should be less or equal 1 as it directly raise the error without backoff
+            self.assertGreaterEqual(1, time_difference)
+
+    def test_url_error_build_report_request(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the URLError.
+        '''
+        mock_client = MockClient(URLError("<urlopen error [Errno 104] Connection reset by peer>"))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.build_report_request(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date')
+        except URLError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)   
+    
+    def test_ssl_eof_error_build_report_request(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                    mock_write_schema, mock_get_bookmark, 
+                                                    mock_sobject_to_dict, mock_write_state, 
+                                                    mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                    mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the SSLEOFError.
+        '''
+        with open('tests/base.py') as f:
+            mock_client = MockClient(ssl.SSLEOFError('EOF occurred in violation of protocol'))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.build_report_request(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date')
+        except ssl.SSLEOFError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+
+    def test_408_exception_build_report_request(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the Exception with error code 408.
+        '''
+        mock_client = MockClient(Exception((408, 'Request Timeout')))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.build_report_request(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date')
+        except Exception:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)  
+
+    def test_connection_reset_error_get_report_schema(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the connection reset error.
+        '''
+        mock_client = MockClient(socket.error(104, 'Connection reset by peer'))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.get_report_schema(mock_client, '')
+        except ConnectionResetError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+        
+    def test_socket_timeout_error_get_report_schema(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the socket timeout error.
+        '''
+        mock_client = MockClient(socket.timeout())
+        before_time = datetime.datetime.now()
+        try:
+           tap_bing_ads.get_report_schema(mock_client, '')
+        except socket.timeout:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+        
+    def test_http_timeout_error_get_report_schema(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                        mock_write_schema, mock_get_bookmark, 
+                                                        mock_sobject_to_dict, mock_write_state, 
+                                                        mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                        mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the http timeout error.
+        '''
+        with open('tests/base.py') as f:
+            mock_client = MockClient(HTTPError('url', 408, 'Request Timeout', {}, f))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.get_report_schema(mock_client, '')
+        except HTTPError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+     
+    def test_internal_server_error_get_report_schema(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the 500 internal server error.
+        '''
+        with open('tests/base.py') as f:
+            mock_client = MockClient(HTTPError('url', 500, 'Internal Server Error', {}, f))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.get_report_schema(mock_client, '')
+        except HTTPError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+
+    def test_transport_error_get_report_schema(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the Transport error.
+        '''
+        mock_client = MockClient(TransportError('url', 500, 'Internal Server Error'))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.get_report_schema(mock_client, '')
+        except TransportError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+
+    def test_400_error_get_report_schema(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many):
+        '''
+        Test that tap does not retry on the 400 error.
+        '''
+        with open('tests/base.py') as f:
+            mock_client = MockClient(HTTPError('url', 400, 'Bad Request', {}, f))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.get_report_schema(mock_client, '')
+        except HTTPError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code raise error without backoff
+            # time_difference should be less or equal 1 as it directly raise the error without backoff
+            self.assertGreaterEqual(1, time_difference)
+
+    def test_url_error_get_report_schema(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the Transport error.
+        '''
+        mock_client = MockClient(URLError("<urlopen error [Errno 104] Connection reset by peer>"))
+        
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.get_report_schema(mock_client, '')
+        except URLError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+    
+    def test_ssl_eof_error_get_report_schema(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                mock_write_schema, mock_get_bookmark, 
+                                                mock_sobject_to_dict, mock_write_state, 
+                                                mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the SSLEOFError.
+        '''
+        with open('tests/base.py') as f:
+            mock_client = MockClient(ssl.SSLEOFError('EOF occurred in violation of protocol'))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.get_report_schema(mock_client, '')
+        except ssl.SSLEOFError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+    
+    def test_exception_408_get_report_schema(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                mock_write_schema, mock_get_bookmark, 
+                                                mock_sobject_to_dict, mock_write_state, 
+                                                mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the Exception with error code 408.
+        '''
+        with open('tests/base.py') as f:
+            mock_client = MockClient(Exception((408, 'Request Timeout')))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.get_report_schema(mock_client, '')
+        except Exception:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+
+                
+    def test_connection_reset_error_get_type_map(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                    mock_write_schema, mock_get_bookmark, 
+                                                    mock_sobject_to_dict, mock_write_state, 
+                                                    mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                    mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the connection reset error.
+        '''
+        mock_client = MockClient(socket.error(104, 'Connection reset by peer'))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.get_type_map(mock_client)
+        except ConnectionResetError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+        
+    def test_socket_timeout_error_get_type_map(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                    mock_write_schema, mock_get_bookmark, 
+                                                    mock_sobject_to_dict, mock_write_state, 
+                                                    mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                    mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the socket timeout error.
+        '''
+        mock_client = MockClient(socket.timeout())
+        before_time = datetime.datetime.now()
+        try:
+           tap_bing_ads.get_type_map(mock_client)
+        except socket.timeout:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+        
+    def test_http_timeout_error_get_type_map(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                mock_write_schema, mock_get_bookmark, 
+                                                mock_sobject_to_dict, mock_write_state, 
+                                                mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the http timeout error.
+        '''
+        with open('tests/base.py') as f:
+            mock_client = MockClient(HTTPError('url', 408, 'Request Timeout', {}, f))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.get_type_map(mock_client)
+        except HTTPError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+     
+    def test_internal_server_error_get_type_map(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                    mock_write_schema, mock_get_bookmark, 
+                                                    mock_sobject_to_dict, mock_write_state, 
+                                                    mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                    mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the 500 internal server error.
+        '''
+        with open('tests/base.py') as f:
+            mock_client = MockClient(HTTPError('url', 500, 'Internal Server Error', {}, f))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.get_type_map(mock_client)
+        except HTTPError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+
+    def test_transport_error_get_type_map(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                    mock_write_schema, mock_get_bookmark, 
+                                                    mock_sobject_to_dict, mock_write_state, 
+                                                    mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                    mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the Transport error.
+        '''
+        mock_client = MockClient(TransportError('url', 500, 'Internal Server Error'))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.get_type_map(mock_client)
+        except TransportError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+        
+    def test_400_error_get_type_map(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                    mock_write_schema, mock_get_bookmark, 
+                                                    mock_sobject_to_dict, mock_write_state, 
+                                                    mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                    mock_filter_selected_fields_many):
+        '''
+        Test that tap does not retry on the 400 error.
+        '''
+        with open('tests/base.py') as f:
+            mock_client = MockClient(HTTPError('url', 400, 'Bad Request', {}, f))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.get_type_map(mock_client)
+        except HTTPError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code raise error without backoff
+            # time_difference should be less or equal 1 as it directly raise the error without backoff
+            self.assertGreaterEqual(1, time_difference)
+
+    def test_url_error_get_type_map(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                    mock_write_schema, mock_get_bookmark, 
+                                                    mock_sobject_to_dict, mock_write_state, 
+                                                    mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                    mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the URLError.
+        '''
+        mock_client = MockClient(URLError("<urlopen error [Errno 104] Connection reset by peer>"))
+        
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.get_type_map(mock_client)
+        except URLError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+   
+    def test_ssl_eof_error_get_type_map(self, mock_get_selected_fields, mock_get_core_schema, 
+                                            mock_write_schema, mock_get_bookmark, 
+                                            mock_sobject_to_dict, mock_write_state, 
+                                            mock_write_bookmark, mock_metrics, mock_write_records, 
+                                            mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the SSLEOFError.
+        '''
+        with open('tests/base.py') as f:
+            mock_client = MockClient(ssl.SSLEOFError('EOF occurred in violation of protocol'))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.get_type_map(mock_client)
+        except ssl.SSLEOFError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+
+    def test_exception_408_get_type_map(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                    mock_write_schema, mock_get_bookmark, 
+                                                    mock_sobject_to_dict, mock_write_state, 
+                                                    mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                    mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the Exception with error code 408.
+        '''
+        mock_client = MockClient(Exception((408, 'Request Timeout')))
+        before_time = datetime.datetime.now()
+        try:
+           tap_bing_ads.get_type_map(mock_client)
+        except Exception:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+
+    async def test_connection_reset_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the connection reset error.
+        '''
+        mock_client = MockClient(socket.error(104, 'Connection reset by peer'))
+        before_time = datetime.datetime.now()
+        try:
+            await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
+        except ConnectionResetError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+        
+    async def test_socket_timeout_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the socket timeout error.
+        '''
+        mock_client = MockClient(socket.timeout())
+        before_time = datetime.datetime.now()
+        try:
+           await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
+        except socket.timeout:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+        
+    async def test_http_timeout_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                        mock_write_schema, mock_get_bookmark, 
+                                                        mock_sobject_to_dict, mock_write_state, 
+                                                        mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                        mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the http timeout error.
+        '''
+        with open('tests/base.py') as f:
+            mock_client = MockClient(HTTPError('url', 408, 'Request Timeout', {}, f))
+        before_time = datetime.datetime.now()
+        try:
+            await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
+        except HTTPError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+     
+    async def test_internal_server_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the 500 internal server error.
+        '''
+        with open('tests/base.py') as f:
+            mock_client = MockClient(HTTPError('url', 500, 'Internal Server Error', {}, f))
+        before_time = datetime.datetime.now()
+        try:
+            await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
+        except HTTPError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+            
+    async def test_transport_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the Transport error.
+        '''
+        mock_client = MockClient(TransportError('url', 500, 'Internal Server Error'))
+        before_time = datetime.datetime.now()
+        try:
+            await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
+        except TransportError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+        
+    async def test_400_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many):
+        '''
+        Test that tap does not retry on the 400 error.
+        '''
+        with open('tests/base.py') as f:
+            mock_client = MockClient(HTTPError('url', 400, 'Bad Request', {}, f))
+        before_time = datetime.datetime.now()
+        try:
+            await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
+        except HTTPError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code raise error without backoff
+            # time_difference should be less or equal 1 as it directly raise the error without backoff
+            self.assertGreaterEqual(1, time_difference)
+
+    async def test_url_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the URLError.
+        '''
+        mock_client = MockClient(URLError("<urlopen error [Errno 104] Connection reset by peer>"))
+        
+        before_time = datetime.datetime.now()
+        try:
+            await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
+        except URLError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+
+    async def test_ssl_eof_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                    mock_write_schema, mock_get_bookmark, 
+                                                    mock_sobject_to_dict, mock_write_state, 
+                                                    mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                    mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the SSLEOFError.
+        '''
+        with open('tests/base.py') as f:
+            mock_client = MockClient(ssl.SSLEOFError('EOF occurred in violation of protocol'))
+        before_time = datetime.datetime.now()
+        try:
+            s = await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
+        except ssl.SSLEOFError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+
+    async def test_exception_408_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the Exception with error code 408.
+        '''
+        mock_client = MockClient(Exception((408, 'Request Timeout')))
+        
+        before_time = datetime.datetime.now()
+        try:
+            await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
+        except Exception:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+
+    @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
+    @mock.patch("bingads.OAuthWebAuthCodeGrant.request_oauth_tokens_by_refresh_token")
+    @mock.patch("bingads.AuthorizationData", return_value = '')
+    @mock.patch("tap_bing_ads.CustomServiceClient")
+    def test_connection_reset_create_sdk_client(self, mock_client, mock_authorization_data, mock_oauth, mock_config,
+                                                        mock_get_selected_fields, mock_get_core_schema, 
+                                                        mock_write_schema, mock_get_bookmark, 
+                                                        mock_sobject_to_dict, mock_write_state, 
+                                                        mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                        mock_filter_selected_fields_many):
+        mock_oauth.return_value = ''
+        mock_client.side_effect = socket.error(104, 'Connection reset by peer')
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.create_sdk_client('dummy_service', {})
+        except ConnectionResetError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+        
+    @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
+    @mock.patch("bingads.OAuthWebAuthCodeGrant.request_oauth_tokens_by_refresh_token")
+    @mock.patch("bingads.AuthorizationData", return_value = '')
+    @mock.patch("tap_bing_ads.CustomServiceClient")
+    def test_socket_timeout_create_sdk_client(self, mock_client, mock_authorization_data, mock_oauth, mock_config,
+                                                    mock_get_selected_fields, mock_get_core_schema, 
+                                                    mock_write_schema, mock_get_bookmark, 
+                                                    mock_sobject_to_dict, mock_write_state, 
+                                                    mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                    mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the socket timeout error.
+        '''
+        mock_oauth.return_value = ''
+        mock_client.side_effect = socket.timeout()
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.create_sdk_client('dummy_service', {})
+        except socket.timeout:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+        
+    @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
+    @mock.patch("bingads.OAuthWebAuthCodeGrant.request_oauth_tokens_by_refresh_token")
+    @mock.patch("bingads.AuthorizationData", return_value = '')
+    @mock.patch("tap_bing_ads.CustomServiceClient")
+    def test_http_timeout_error_create_sdk_client(self, mock_client, mock_authorization_data, mock_oauth, mock_config, 
+                                                        mock_get_selected_fields, mock_get_core_schema, 
+                                                        mock_write_schema, mock_get_bookmark, 
+                                                        mock_sobject_to_dict, mock_write_state, 
+                                                        mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                        mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the http timeout error.
+        '''
+        mock_oauth.return_value = ''
+        with open('tests/base.py') as f:
+            mock_client.side_effect = HTTPError('url', 408, 'Request Timeout', {}, f)
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.create_sdk_client('dummy_service', {})
+        except HTTPError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+        
+    @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
+    @mock.patch("bingads.OAuthWebAuthCodeGrant.request_oauth_tokens_by_refresh_token")
+    @mock.patch("bingads.AuthorizationData", return_value = '')
+    @mock.patch("tap_bing_ads.CustomServiceClient")
+    def test_internal_server_error_create_sdk_client(self, mock_client, mock_authorization_data, mock_oauth, mock_config,
+                                                           mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the 500 internal server error.
+        '''
+        mock_oauth.return_value = ''
+        with open('tests/base.py') as f:
+            mock_client.side_effect = HTTPError('url', 500, 'Internal Server Error', {}, f)
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.create_sdk_client('dummy_service', {})
+        except HTTPError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+        
+    @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
+    @mock.patch("bingads.OAuthWebAuthCodeGrant.request_oauth_tokens_by_refresh_token")
+    @mock.patch("bingads.AuthorizationData", return_value = '')
+    @mock.patch("tap_bing_ads.CustomServiceClient")
+    def test_transport_error_create_sdk_client(self, mock_client, mock_authorization_data, mock_oauth, mock_config,
+                                                    mock_get_selected_fields, mock_get_core_schema, 
+                                                    mock_write_schema, mock_get_bookmark, 
+                                                    mock_sobject_to_dict, mock_write_state, 
+                                                    mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                    mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the Transport error.
+        '''
+        mock_oauth.return_value = ''
+        mock_client.side_effect = TransportError('url', 500, 'Internal Server Error')
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.create_sdk_client('dummy_service', {})
+        except TransportError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+        
+    @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
+    @mock.patch("bingads.OAuthWebAuthCodeGrant.request_oauth_tokens_by_refresh_token")
+    @mock.patch("bingads.AuthorizationData", return_value = '')
+    @mock.patch("tap_bing_ads.CustomServiceClient")
+    def test_400_error_create_sdk_client(self, mock_client, mock_authorization_data, mock_oauth, mock_config,
+                                                mock_get_selected_fields, mock_get_core_schema, 
+                                                mock_write_schema, mock_get_bookmark, 
+                                                mock_sobject_to_dict, mock_write_state, 
+                                                mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                mock_filter_selected_fields_many):
+        '''
+        Test that tap does not retry on the 400 error.
+        '''
+        mock_oauth.return_value = ''
+        with open('tests/base.py') as f:
+            mock_client.side_effect = HTTPError('url', 400, 'Bad Request', {}, f)
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.create_sdk_client('dummy_service', {})
+        except HTTPError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code raise error without backoff
+            # time_difference should be less or equal 1 as it directly raise the error without backoff
+            self.assertGreaterEqual(1, time_difference)
+        
+        
+    @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
+    @mock.patch("bingads.OAuthWebAuthCodeGrant.request_oauth_tokens_by_refresh_token")
+    @mock.patch("bingads.AuthorizationData", return_value = '')
+    @mock.patch("tap_bing_ads.CustomServiceClient")
+    def test_ssl_eof_error_create_sdk_client(self, mock_client, mock_authorization_data, mock_oauth, mock_config,
+                                                           mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the SSLEOFError.
+        '''
+        mock_oauth.return_value = ''
+        with open('tests/base.py') as f:
+            mock_client.side_effect = ssl.SSLEOFError('EOF occurred in violation of protocol')
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.create_sdk_client('dummy_service', {})
+        except ssl.SSLEOFError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+
+    @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
+    @mock.patch("bingads.OAuthWebAuthCodeGrant.request_oauth_tokens_by_refresh_token")
+    @mock.patch("bingads.AuthorizationData", return_value = '')
+    @mock.patch("tap_bing_ads.CustomServiceClient")
+    def test_url_error_create_sdk_client(self, mock_client, mock_authorization_data, mock_oauth, mock_config,
+                                                    mock_get_selected_fields, mock_get_core_schema, 
+                                                    mock_write_schema, mock_get_bookmark, 
+                                                    mock_sobject_to_dict, mock_write_state, 
+                                                    mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                    mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the Transport error.
+        '''
+        mock_oauth.return_value = ''
+        mock_client.side_effect = URLError("<urlopen error [Errno 104] Connection reset by peer>")
+        
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.create_sdk_client('dummy_service', {})
+        except URLError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+
+    @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
+    @mock.patch("bingads.OAuthWebAuthCodeGrant.request_oauth_tokens_by_refresh_token")
+    @mock.patch("bingads.AuthorizationData", return_value = '')
+    @mock.patch("tap_bing_ads.CustomServiceClient")
+    def test_exception_408_error_create_sdk_client(self, mock_client, mock_authorization_data, mock_oauth, mock_config,
+                                                    mock_get_selected_fields, mock_get_core_schema, 
+                                                    mock_write_schema, mock_get_bookmark, 
+                                                    mock_sobject_to_dict, mock_write_state, 
+                                                    mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                    mock_filter_selected_fields_many):
+        '''
+        Test that tap retry for 60 seconds on the Exception with error code 408.
+        '''
+        mock_oauth.return_value = ''
+        mock_client.side_effect = Exception((408, 'Request Timeout'))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.create_sdk_client('dummy_service', {})
+        except Exception:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+

--- a/tests/unittests/test_request_timeout.py
+++ b/tests/unittests/test_request_timeout.py
@@ -1,0 +1,385 @@
+import unittest
+from unittest import mock
+
+from requests.exceptions import Timeout
+import tap_bing_ads
+from urllib.error import URLError
+from tap_bing_ads import CustomServiceClient
+import datetime
+    
+class MockClient():
+    '''Mocked ServiceClient class and it's method to pass the test case'''
+    def __init__(self, error):
+        self.error = error
+        self.count = 0
+
+    def GetCampaignsByAccountId(self, AccountId, CampaignType):
+        '''Mocked GetCampaignsByAccountId method of the Client class'''
+        self.count = self.count + 1
+        raise self.error
+
+    def GetAdGroupsByCampaignId(self, CampaignId):
+        '''Mocked GetAdGroupsByCampaignId method of the Client class'''
+        self.count = self.count + 1
+        raise self.error
+
+    def GetAdsByAdGroupId(self, AdGroupId, AdTypes):
+        '''Mocked GetAdsByAdGroupId method of the Client class'''
+        self.count = self.count + 1
+        raise self.error
+
+    def PollGenerateReport(self):
+        '''Mocked PollGenerateReport method of the Client class'''
+        self.count = self.count + 1
+        raise self.error
+
+    def SubmitGenerateReport(self, report_request):
+        '''Mocked SubmitGenerateReport method of the Client class'''
+        self.count = self.count + 1
+        raise self.error
+
+    def PollGenerateReport(self, request_id):
+        '''Mocked PollGenerateReport method of the Client class'''
+        self.count = self.count + 1
+        raise self.error
+
+    @property
+    def factory(self):
+        '''Mocked factory property of the Client class'''
+        self.count = self.count + 1
+        raise self.error
+
+    @property
+    def soap_client(self):
+        '''Mocked soap_client property of the Client class'''
+        self.count = self.count + 1
+        raise self.error
+
+    @property
+    def call_count(self):
+        '''Mocked call_count property of the Client class'''
+        return self.count
+
+@mock.patch("tap_bing_ads.filter_selected_fields_many", return_value = '')
+@mock.patch("singer.write_records", return_value = '')
+@mock.patch("singer.metrics", return_value = '')
+@mock.patch("singer.write_bookmark", return_value = '')
+@mock.patch("singer.write_state", return_value = '')
+@mock.patch("tap_bing_ads.sobject_to_dict", return_value = '')
+@mock.patch("singer.get_bookmark", return_value = {'b1': 'b1'})
+@mock.patch("singer.write_schema", return_value = '')
+@mock.patch("tap_bing_ads.get_core_schema", return_value = '')
+@mock.patch("tap_bing_ads.get_selected_fields", return_value = '')
+class TestBackoffError(unittest.TestCase):
+    '''
+    Test that backoff logic works properly. Mocked some common method to test the backoff including
+    filter_selected_fields_many, write_records , metrics, write_bookmark, write_state, sobject_to_dict,
+    get_bookmark, write_schema, get_core_schema, get_selected_fields, time.sleep.
+    '''
+    @mock.patch("tap_bing_ads.create_sdk_client", return_value = '')
+    @mock.patch("tap_bing_ads.CustomServiceClient")
+    def test_url_error_get_account(self, mock_get_account, mock_create_sdk_client,
+                                                    mock_get_selected_fields, mock_get_core_schema,
+                                                    mock_write_schema, mock_get_bookmark,
+                                                    mock_sobject_to_dict, mock_write_state,
+                                                    mock_write_bookmark, mock_metrics, mock_write_records,
+                                                    mock_filter_selected_fields_many):
+        '''
+        Test that tap retry on the url timeout error for 60 seconds.
+        '''
+        mock_get_account.side_effect = URLError('_ssl.c:1059: The handshake operation timed out')
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.sync_accounts_stream(['i1'], {})
+        except URLError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+
+    def test_url_error_sync_campaigns(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                        mock_write_schema, mock_get_bookmark, 
+                                                        mock_sobject_to_dict, mock_write_state, 
+                                                        mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                        mock_filter_selected_fields_many):
+        '''
+        Test that tap retry on the timeout error for 1 minute.
+        '''
+        mock_client = MockClient(URLError('_ssl.c:1059: The handshake operation timed out'))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.sync_campaigns(mock_client, '', [])
+        except URLError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+
+    def test_url_error_sync_ad_groups(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                        mock_write_schema, mock_get_bookmark, 
+                                                        mock_sobject_to_dict, mock_write_state, 
+                                                        mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                        mock_filter_selected_fields_many):
+        '''
+        Test that tap retry on the timeout error for 1 minute.
+        '''
+        mock_client = MockClient(URLError('_ssl.c:1059: The handshake operation timed out'))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.sync_ad_groups(mock_client, '', ['dummy_campaign_id'], [])
+        except URLError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+
+    def test_url_error_sync_ads(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                mock_write_schema, mock_get_bookmark, 
+                                                mock_sobject_to_dict, mock_write_state, 
+                                                mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                mock_filter_selected_fields_many):
+        '''
+        Test that tap retry on the timeout error for 1 minute.
+        '''
+        mock_client = MockClient(URLError('_ssl.c:1059: The handshake operation timed out'))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.sync_ads(mock_client, ['dummy_stream'], ['dummy_ad_id'])
+        except URLError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60) 
+
+    @mock.patch("tap_bing_ads.build_report_request")
+    def test_url_error_get_report_request_id(self, mock_build_report_request, 
+                                                           mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many):
+        '''
+        Test that tap retry on the timeout error for 1 minute.
+        '''
+        mock_client = MockClient(URLError('_ssl.c:1059: The handshake operation timed out'))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.get_report_request_id(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date', 'dummy_start_key',
+                                                force_refresh = True)
+        except URLError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+
+    def test_url_error_build_report_request(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many):
+        '''
+        Test that tap retry on the timeout error for 1 minute.
+        '''
+        mock_client = MockClient(URLError('_ssl.c:1059: The handshake operation timed out'))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.build_report_request(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date')
+        except URLError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+
+    def test_url_error_get_type_map(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                    mock_write_schema, mock_get_bookmark, 
+                                                    mock_sobject_to_dict, mock_write_state, 
+                                                    mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                    mock_filter_selected_fields_many):
+        '''
+        Test that tap retry on the timeout error for 1 minute.
+        '''
+        mock_client = MockClient(URLError('_ssl.c:1059: The handshake operation timed out'))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.get_type_map(mock_client)
+        except URLError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+
+    def test_url_error_get_report_schema(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                    mock_write_schema, mock_get_bookmark, 
+                                                    mock_sobject_to_dict, mock_write_state, 
+                                                    mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                    mock_filter_selected_fields_many):
+        '''
+        Test that tap retry on the timeout error for 1 minute.
+        '''
+        mock_client = MockClient(URLError('_ssl.c:1059: The handshake operation timed out'))
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.get_report_schema(mock_client, '')
+        except URLError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+
+    async def test_url_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
+                                                           mock_write_schema, mock_get_bookmark, 
+                                                           mock_sobject_to_dict, mock_write_state, 
+                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                           mock_filter_selected_fields_many):
+        '''
+        Test that tap retry on the timeout error for 1 minute.
+        '''
+        mock_client = MockClient(URLError('_ssl.c:1059: The handshake operation timed out'))
+        before_time = datetime.datetime.now()
+        try:
+            await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
+        except URLError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+
+    @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
+    @mock.patch("bingads.OAuthWebAuthCodeGrant.request_oauth_tokens_by_refresh_token")
+    @mock.patch("bingads.AuthorizationData", return_value = '')
+    @mock.patch("tap_bing_ads.CustomServiceClient")
+    def test_url_error_create_sdk_client(self, mock_client, mock_authorization_data, mock_oauth, mock_config,
+                                                        mock_get_selected_fields, mock_get_core_schema, 
+                                                        mock_write_schema, mock_get_bookmark, 
+                                                        mock_sobject_to_dict, mock_write_state, 
+                                                        mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                        mock_filter_selected_fields_many):
+        '''
+        Test that tap retry on the timeout error for 1 minute.
+        '''
+        mock_oauth.return_value = ''
+        mock_client.side_effect = URLError('_ssl.c:1059: The handshake operation timed out')
+        before_time = datetime.datetime.now()
+        try:
+            tap_bing_ads.create_sdk_client('dummy_service', {})
+        except URLError:
+            after_time = datetime.datetime.now()
+            time_difference = (after_time - before_time).total_seconds()
+            # verify the code backed off for 60 seconds
+            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
+            self.assertGreaterEqual(time_difference, 60)
+
+    @mock.patch('tap_bing_ads.requests.Session.get')
+    def test_timeout_error_stream_report(self, mocked_get, mock_get_selected_fields, mock_get_core_schema, 
+                                                        mock_write_schema, mock_get_bookmark, 
+                                                        mock_sobject_to_dict, mock_write_state, 
+                                                        mock_write_bookmark, mock_metrics, mock_write_records, 
+                                                        mock_filter_selected_fields_many):
+        '''
+        Test that tap retry on the timeout error for 5 times.
+        '''
+        mocked_get.side_effect = Timeout
+        try:
+            tap_bing_ads.stream_report('dummy_report', '', 'http://test.com', 'dummy_time')
+        except Timeout:
+            # verify that the request backoffs for 5 times in case of Timeout error
+            self.assertEqual(mocked_get.call_count, 5)
+
+# Mock Client 
+class MockedClient():
+    def __init__(self) -> None:
+        pass
+
+# Mock args
+class Args():
+    def __init__(self, config):
+        self.config = config
+        self.discover = False
+        self.properties = False
+        self.catalog = False
+        self.state = False
+
+@mock.patch('tap_bing_ads.utils.parse_args')
+@mock.patch("bingads.OAuthWebAuthCodeGrant.request_oauth_tokens_by_refresh_token")
+@mock.patch("bingads.AuthorizationData", return_value = '')
+@mock.patch("bingads.Client.set_options")
+@mock.patch("tap_bing_ads.CustomServiceClient")
+class TestRequestTimeoutValue(unittest.TestCase):
+    def test_default_value_request_timeout(self, mock_client, mock_set_options, mock_authorization_data, mock_oauth, mocked_args):
+        """ 
+            Unit tests to ensure that request timeout is set based default value
+        """
+        tap_bing_ads.CONFIG = {}
+        config = {"customer_id": "test", "oauth_client_id": "test", "oauth_client_secret": "test", "refresh_token": "test", "developer_token": "test"}
+        args = Args(config)
+        tap_bing_ads.CONFIG.update(args.config)
+        kwargs = {'headers': {}}
+        mock_client.side_effect == MockedClient
+        service_client = CustomServiceClient('CustomerManagementService')
+        service_client.set_options(**kwargs)
+        mock_set_options.assert_called_with(headers={'User-Agent': 'Singer.io Bing Ads Tap'}, timeout=300.0)
+    
+    def test_config_provided_request_timeout(self, mock_client, mock_set_options, mock_authorization_data, mock_oauth, mocked_args):
+        """ 
+            Unit tests to ensure that request timeout is set based on config value
+        """
+        tap_bing_ads.CONFIG = {}
+        config = {"customer_id": "test", "oauth_client_id": "test", "oauth_client_secret": "test", "refresh_token": "test", "developer_token": "test", 'request_timeout': 100}
+        args = Args(config)
+        tap_bing_ads.CONFIG.update(args.config)
+        kwargs = {'headers': {}}
+        mock_client.side_effect == MockedClient
+        service_client = CustomServiceClient('CustomerManagementService')
+        service_client.set_options(**kwargs)
+        mock_set_options.assert_called_with(headers={'User-Agent': 'Singer.io Bing Ads Tap'}, timeout=100.0)
+
+    def test_float_config_provided_request_timeout(self, mock_client, mock_set_options, mock_authorization_data, mock_oauth, mocked_args):
+        """ 
+            Unit tests to ensure that request timeout is set based on config float value
+        """
+        tap_bing_ads.CONFIG = {}
+        config = {"customer_id": "test", "oauth_client_id": "test", "oauth_client_secret": "test", "refresh_token": "test", "developer_token": "test", 'request_timeout': 100.8}
+        args = Args(config)
+        tap_bing_ads.CONFIG.update(args.config)
+        kwargs = {'headers': {}}
+        mock_client.side_effect == MockedClient
+        service_client = CustomServiceClient('CustomerManagementService')
+        service_client.set_options(**kwargs)
+        mock_set_options.assert_called_with(headers={'User-Agent': 'Singer.io Bing Ads Tap'}, timeout=100.8)
+    
+    def test_string_config_provided_request_timeout(self, mock_client, mock_set_options, mock_authorization_data, mock_oauth, mocked_args):
+        """ 
+            Unit tests to ensure that request timeout is set based on config string value
+        """
+        tap_bing_ads.CONFIG = {}
+        config = {"customer_id": "test", "oauth_client_id": "test", "oauth_client_secret": "test", "refresh_token": "test", "developer_token": "test", 'request_timeout': '100'}
+        args = Args(config)
+        tap_bing_ads.CONFIG.update(args.config)
+        kwargs = {'headers': {}}
+        mock_client.side_effect == MockedClient
+        service_client = CustomServiceClient('CustomerManagementService')
+        service_client.set_options(**kwargs)
+        mock_set_options.assert_called_with(headers={'User-Agent': 'Singer.io Bing Ads Tap'}, timeout=100.0)
+    
+    def test_empty_config_provided_request_timeout(self, mock_client, mock_set_options, mock_authorization_data, mock_oauth, mocked_args):
+        """ 
+            Unit tests to ensure that request timeout is set based on default value if empty value is given in config
+        """
+        tap_bing_ads.CONFIG = {}
+        config = {"customer_id": "test", "oauth_client_id": "test", "oauth_client_secret": "test", "refresh_token": "test", "developer_token": "test", 'request_timeout': ''}
+        args = Args(config)
+        tap_bing_ads.CONFIG.update(args.config)
+        kwargs = {'headers': {}}
+        mock_client.side_effect == MockedClient
+        service_client = CustomServiceClient('CustomerManagementService')
+        service_client.set_options(**kwargs)
+        mock_set_options.assert_called_with(headers={'User-Agent': 'Singer.io Bing Ads Tap'}, timeout=300.0)

--- a/tests/unittests/test_stream_def.py
+++ b/tests/unittests/test_stream_def.py
@@ -1,0 +1,50 @@
+import unittest
+from unittest import mock
+from tap_bing_ads import get_stream_def
+
+class TestStreamDef(unittest.TestCase):
+    """A set of unit tests to ensure that we are getting proper schema and metadata for each streams"""
+    
+    # Mocking metadata
+    def mock_metadata(*args):
+        return {(): {'table-key-properties': ['Id'], 'forced-replication-method': 'INCREMENTAL', 'valid-replication-keys': 'LastModifiedTime', 'inclusion': 'available'}, ('properties', 'BillToCustomerId'): {'inclusion': 'available'}, ('properties', 'CurrencyCode'): {'inclusion': 'available', 'fieldExclusions': [['properties', 'BidMatchType'], ['properties', 'DeviceOS'], ['properties', 'Goal'], ['properties', 'GoalType'], ['properties', 'TopVsOther']]}, ('properties', 'AccountFinancialStatus'): {'inclusion': 'available'}, ('properties', 'Id'): {'inclusion': 'automatic'}, ('properties', 'Language'): {'inclusion': 'available'}, ('properties', 'LastModifiedByUserId'): {'inclusion': 'available'}, ('properties', 'LastModifiedTime'): {'inclusion': 'available'}, ('properties', 'Name'): {'inclusion': 'available'}}
+
+    # Mocking metadata.write method
+    def mock_write(mdata,tpl,incl='inclusion', val='automatic'):
+        if isinstance(tpl[1],list):
+            mdata[(tpl[0],tpl[1][0])] = {incl: val}
+        else:
+            mdata[tpl] = {incl: val}
+        return mdata
+
+    # Mocking metadata.to_list method
+    def mock_to_list(mdata):
+        return [{'breadcrumb': (), 'metadata': {'table-key-properties': ['Id'], 'forced-replication-method': 'INCREMENTAL', 'valid-replication-keys': 'LastModifiedTime', 'inclusion': 'available'}}, {'breadcrumb': ('properties', 'BillToCustomerId'), 'metadata': {'inclusion': 'available'}}, {'breadcrumb': ('properties', 'CurrencyCode'), 'metadata': {'inclusion': 'automatic', 'fieldExclusions': [['properties', 'BidMatchType'], ['properties', 'DeviceOS'], ['properties', 'Goal'], ['properties', 'GoalType'], ['properties', 'TopVsOther']]}}, {'breadcrumb': ('properties', 'AccountFinancialStatus'), 'metadata': {'inclusion': 'available'}}, {'breadcrumb': ('properties', 'Id'), 'metadata': {'inclusion': 'automatic'}}, {'breadcrumb': ('properties', 'Language'), 'metadata': {'inclusion': 'available'}}, {'breadcrumb': ('properties', 'LastModifiedByUserId'), 'metadata': {'inclusion': 'available'}}, {'breadcrumb': ('properties', 'LastModifiedTime'), 'metadata': {'inclusion': 'automatic'}}, {'breadcrumb': ('properties', 'Name'), 'metadata': {'inclusion': 'available'}}]
+
+    @mock.patch("singer.metadata.get_standard_metadata")
+    @mock.patch("singer.metadata.to_map",side_effect=mock_metadata)
+    @mock.patch("singer.metadata.write", side_effect=mock_write)
+    @mock.patch("singer.metadata.to_list", side_effect=mock_to_list)
+    def test_get_stream_def_for_account_stream(self,mock_to_list,mock_write,mock_metadata, mock_get_standard_metadata):
+        """ 
+        Call get_stream_def function for a stream and validate primary keys, automatic keys and replication keys assignment
+        """
+        # Defined mock variables to call get_stream_def function for account stream
+        mock_stream_name = 'test_accounts'
+        mock_schema = {'type':['null','object'],'additionalProperties':False,'properties':{'BillToCustomerId':{'type':['null','integer']},'CurrencyCode':{'type':['null','string']},'AccountFinancialStatus':{'type':['null','string']},'Id':{'type':['null','integer']},'Language':{'type':['null','string']},'LastModifiedByUserId':{'type':['null','integer']},'LastModifiedTime':{'type':['null','string'],'format':'date-time'},'Name':{'type':['null','string']}}}
+        mock_stream_metadata = [{'metadata': {'inclusion': 'automatic','fieldExclusions':[['properties','BidMatchType'],['properties','DeviceOS'],['properties','Goal'],['properties','GoalType'],['properties','TopVsOther']]}, 'breadcrumb': ['properties','CurrencyCode']}]
+        mock_pks=['Id']
+        mock_replication_key=['LastModifiedTime']
+        stream_response = get_stream_def(mock_stream_name, mock_schema, mock_stream_metadata, mock_pks, mock_replication_key)
+
+        # Verify top-level breadcrum is available
+        self.assertEquals(stream_response.get('metadata')[0].get('breadcrumb'),())
+        self.assertEquals(stream_response.get('metadata')[0].get('metadata'),{'table-key-properties': ['Id'], 'forced-replication-method': 'INCREMENTAL', 'valid-replication-keys': 'LastModifiedTime', 'inclusion': 'available'})
+
+        # Verify pks, replication_keys and automatic_keys in mock_stream_metadata must be automatic in metadata
+        for field in stream_response.get('metadata'):
+            if field.get('breadcrumb') in [('properties', 'Id'),('properties', 'LastModifiedTime'),('properties', 'CurrencyCode')]:
+                self.assertEquals(field.get('metadata').get('inclusion'),'automatic')
+            if field.get('breadcrumb') == ('properties', 'CurrencyCode'):
+                # verify fieldExclusions
+                self.assertEquals(field.get('metadata').get('fieldExclusions'),[['properties','BidMatchType'],['properties','DeviceOS'],['properties','Goal'],['properties','GoalType'],['properties','TopVsOther']])


### PR DESCRIPTION
# Description of change

- [TDL-15861 implement request timeout](https://github.com/singer-io/tap-bing-ads/pull/93)
- [TDL-9721 missing top level breadcrumb for all streams](https://github.com/singer-io/tap-bing-ads/pull/91)
- [TDL 7402 Add retry logic for 500 errors](https://github.com/singer-io/tap-bing-ads/pull/90)
- [TDL-16888 Added code comments ](https://github.com/singer-io/tap-bing-ads/pull/88)
- [TDL-6737 added pylint and resolved the errors](https://github.com/singer-io/tap-bing-ads/pull/87)
- [TDL-15251: Add required fields for age_gender_audience_report](https://github.com/singer-io/tap-bing-ads/pull/86)
- [TDL-9902 removed the automatic fields from ad ext report](https://github.com/singer-io/tap-bing-ads/pull/85) 


# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
