### PR TITLE
Bump version for Bing Ads Reliability Changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.20
+  * Implement Timeout Request [#93](https://github.com/singer-io/tap-bing-ads/pull/93)
+  * Added Top Level Breadcrumb [#91](https://github.com/singer-io/tap-bing-ads/pull/91)
+  * Added Retry Logic for 500 errors [#90](https://github.com/singer-io/tap-bing-ads/pull/90)
+  * Added required fields for age_gender_audience_report [#86](https://github.com/singer-io/tap-bing-ads/pull/86)
+  * Removed automatic fields from ad_ext report [#85](https://github.com/singer-io/tap-bing-ads/pull/85)
+
+
 ## 2.1.0
   * Update the BingAds library to `13.0.11`
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='tap-bing-ads',
-    version="2.1.0",
+    version="2.2.0",
     description='Singer.io tap for extracting data from the Bing Ads API',
     author='Stitch',
     url='http://singer.io',


### PR DESCRIPTION
# Description of change
TDL-15861 implement request timeout
TDL-9721 missing top level breadcrumb for all streams
TDL 7402 Add retry logic for 500 errors
TDL-16888 Added code comments
TDL-6737 added pylint and resolved the errors
TDL-15251: Add required fields for age_gender_audience_report
TDL-9902 removed the automatic fields from ad ext report

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
