### PR TITLE
Prefer Microsoft Identity Platform Authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,14 @@
 # Changelog
 
-## 2.20
+## 2.2.1
+  * Prefer new authentication scope for the access_token request [#99](https://github.com/singer-io/tap-bing-ads/pull/99)
+
+## 2.2.0
   * Implement Timeout Request [#93](https://github.com/singer-io/tap-bing-ads/pull/93)
   * Added Top Level Breadcrumb [#91](https://github.com/singer-io/tap-bing-ads/pull/91)
   * Added Retry Logic for 500 errors [#90](https://github.com/singer-io/tap-bing-ads/pull/90)
   * Added required fields for age_gender_audience_report [#86](https://github.com/singer-io/tap-bing-ads/pull/86)
   * Removed automatic fields from ad_ext report [#85](https://github.com/singer-io/tap-bing-ads/pull/85)
-
 
 ## 2.1.0
   * Update the BingAds library to `13.0.11`

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,9 @@ setup(
     py_modules=['tap_bingads'],
     install_requires=[
         'arrow==0.12.0',
-        'bingads==13.0.11',
+        # Seems that suds-community is now the reference for 13.0.11.1 so we can install it now with the removal of use_2to3
+        # https://github.com/BingAds/BingAds-Python-SDK/pull/192
+        'bingads==13.0.11.1',
         'requests==2.20.0',
         'singer-python==5.9.0',
         'stringcase==1.2.0',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='tap-bing-ads',
-    version="2.2.0",
+    version="2.2.1",
     description='Singer.io tap for extracting data from the Bing Ads API',
     author='Stitch',
     url='http://singer.io',


### PR DESCRIPTION
# Description of change
This PR is to bring the tap up to modern methods of authentication. Currently, the code prefers the old method unless told via a config option which will fail after March 1st.

This PR does a couple of things:
1. Removes the config option in preference of feature detection with the refresh token
2. Tries the modern method (Microsoft Identity Platform, which is the default for the client library and uses the `"offline_access https://ads.microsoft.com/msads.manage"` scopes) then catches the exception thrown if the connection hasn't been re-authed with the newest scope and falls back to the original scope.

# Manual QA steps
 - Created a connection authenticated against the `bingads.manage` and the `"offline_access https://ads.microsoft.com/msads.manage"` scopes.
 - Ran the tap without the try/catch with both, the old scope token fails
 - Ran with the try/catch and both connections succeeded
 
# Risks
 - Low, this shouldn't cause issues until potentially March 1st if something has been missed.
 
# Rollback steps
 - revert this branch
