### PR TITLE
Data 347 microsoft ads export refresh token expires after 90 days

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,9 @@ ENV/
 
 # IDE
 .idea
+
+# Singer config
+config.json
+tap-*.json
+target-*.json
+*config.json

--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ celerybeat-schedule
 # virtualenv
 venv/
 ENV/
+.venv
 
 # Spyder project settings
 .spyderproject
@@ -95,3 +96,6 @@ ENV/
 # Singer files
 *.config.json
 *.catalog.json
+
+# IDE
+.idea

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='tap-bing-ads',
-    version="2.2.1",
+    version="2.3.0",
     description='Singer.io tap for extracting data from the Bing Ads API',
     author='Stitch',
     url='http://singer.io',


### PR DESCRIPTION
# Description of change
Saves response token from MS OAuth to SSM, required at least every 90 days.
