### PR TITLE
Sync streams one at a time

### DIFF
--- a/tap_bing_ads/__init__.py
+++ b/tap_bing_ads/__init__.py
@@ -1062,11 +1062,17 @@ async def do_sync_all_accounts(account_ids, catalog):
         LOGGER.info('Syncing Accounts')
         sync_accounts_stream(account_ids, selected_streams['accounts'])
 
-    sync_account_data_tasks = [
-        sync_account_data(account_id, catalog, selected_streams)
-        for account_id in account_ids
-    ]
-    await asyncio.gather(*sync_account_data_tasks)
+    for stream, catalog_entry in selected_streams.items():
+        LOGGER.info('Syncing %s', stream)
+
+        sync_account_data_tasks = [
+            sync_account_data(account_id,
+                              catalog,
+                              {stream: catalog_entry})
+            for account_id in account_ids
+        ]
+        await asyncio.gather(*sync_account_data_tasks)
+
 
 async def main_impl():
     args = utils.parse_args(REQUIRED_CONFIG_KEYS)


### PR DESCRIPTION
# Description of change
This PR alters the tap code to run tasks for a single stream at a time.

Previously, the tap would create tasks for every selected stream, which resulted in SDK calls to Bing services all at once. This seems to cause an internal error occasionally.

# Manual QA steps
 - Ran the tap to see that syncing all selected streams still occurred
 
# Risks
 - Moderate. I was not able to reproduce the Internal Error myself. But nothing went wrong while running this code. 
 - If this were to be merged, I'm not sure how it would affect people running this tap with a ton of accounts. Maybe some people actually rely on the async calls to all happen at once. This removes some of that, so data extraction times would almost certainly go up
 
# Rollback steps
 - revert this branch
