### PR TITLE
Add optional 'tenant' config option

### DIFF
--- a/tap_bing_ads/__init__.py
+++ b/tap_bing_ads/__init__.py
@@ -163,7 +163,8 @@ def get_authentication():
         authentication = OAuthWebAuthCodeGrant(
             CONFIG['oauth_client_id'],
             CONFIG['oauth_client_secret'],
-            '') ## redirect URL not needed for refresh token
+            '',
+            tenant=CONFIG.get('tenant', 'common')) ## redirect URL not needed for refresh token
         # Retrieves OAuth access and refresh tokens from the Microsoft Account authorization service.
         authentication.request_oauth_tokens_by_refresh_token(CONFIG['refresh_token'])
         return authentication
@@ -172,7 +173,8 @@ def get_authentication():
             CONFIG['oauth_client_id'],
             CONFIG['oauth_client_secret'],
             '',
-            oauth_scope='bingads.manage') ## redirect URL not needed for refresh token
+            oauth_scope='bingads.manage',
+            tenant=CONFIG.get('tenant', 'common')) ## redirect URL not needed for refresh token
         # Retrieves OAuth access and refresh tokens from the Microsoft Account authorization service.
         authentication.request_oauth_tokens_by_refresh_token(CONFIG['refresh_token'])
         return authentication


### PR DESCRIPTION
# Description of change

Providing the "tenant ID" of a single tenant (single organization) app is necessary for successful authentication, as they cannot be authorized via the /common endpoint. Additionally, a developer cannot easily choose to configure an app intended for internal use only as a multi-tenant app to work around this, because multi-tenant apps now require signing up as a Microsoft Partner.

This PR allows new "tenant" config option to be passed to specify a "tenant ID" to use, which is already a supported by the underlying Bing Ads API Python SDK. The config option is entirely optional, and it defaults to "common" to preserve existing behaviour by default ("common" is the value the Bing Ads API Python SDK is already using by default since this tap is currently not providing the optional argument).

# Manual QA steps
 - I've successfully used this new option to authenticate a single tenant app.
 - It would be worth someone who is already using it successfully with a multi-tenant app and the /common endpoint testing that it still works for them
 
# Risks
 - I've not added any tests for this new option as I don't normally work in Python and can't see any documentation on running the tests in the README - so didn't spend the time to figure it out (yet). I thought it was best to try contributing this change upstream sooner rather than later though.
 
# Rollback steps
 - revert this branch
