### PR TITLE
fix: Adds setuptools dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
         'requests==2.32.4',
         'singer-python==6.0.1',
         'backoff==2.2.1',
+        'setuptools>=65.5.0',
     ],
     extras_require={
         'test': [


### PR DESCRIPTION
# Description of change

As referenced in https://github.com/python/cpython/pull/101039 the `setuptools` dependency is no longer bundled automatically.  Presumably it used to be pulled in with venv.

This pull request should fix https://github.com/singer-io/tap-bing-ads/issues/115

# Manual QA steps
The issue can be reproduced by following these steps on master branch in a clean environment;
```
python3.13 -m venv venv
source venv/bin/activate
pip install tap-bing-ads
tap-bing-ads --help 
```
On this branch the help should be displayed.

# Risks
- None, the library used to be included
 
# Rollback steps
 - revert this branch