### PR TITLE
PR 1 - GL Work

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,16 +10,17 @@ jobs:
       - run:
           name: 'Setup virtual env'
           command: |
-            uv venv --python 3.11 /usr/local/share/virtualenvs/tap-bing-ads
+            uv venv --python 3.12 /usr/local/share/virtualenvs/tap-bing-ads
             source /usr/local/share/virtualenvs/tap-bing-ads/bin/activate
-            uv pip install -U pip 'setuptools<51.0.0'
+            uv pip install -U pip setuptools
             uv pip install .[test]
+            uv pip install .[dev]
             uv pip install pylint
       - run:
           name: 'pylint'
           command: |
             source /usr/local/share/virtualenvs/tap-bing-ads/bin/activate
-            pylint tap_bing_ads -d missing-docstring,line-too-long,invalid-name,super-with-arguments,return-in-init,too-many-arguments,deprecated-method,consider-using-f-string,too-many-lines,unidiomatic-typecheck,consider-using-generator,broad-exception-raised
+            pylint tap_bing_ads -d C,R,W
       - run:
           name: 'Unit Tests'
           command: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.4.0
+  * Metadata fields updated for parent streams [#121](https://github.com/singer-io/tap-bing-ads/pull/121)
+
 ## 2.3.2
   * Dependency upgrades [#119](https://github.com/singer-io/tap-bing-ads/pull/119)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 2.4.0
-  * Metadata fields updated for parent streams [#121](https://github.com/singer-io/tap-bing-ads/pull/121)
+  * Metadata fields updated for parent streams [#123](https://github.com/singer-io/tap-bing-ads/pull/123)
 
 ## 2.3.2
   * Dependency upgrades [#119](https://github.com/singer-io/tap-bing-ads/pull/119)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.4.0
   * Metadata fields updated for parent streams [#123](https://github.com/singer-io/tap-bing-ads/pull/123)
   * Python version upgrade to version 3.12 in circleci
+  * module bingads version upgrade to 13.0.28
 
 # 2.3.3
   * Bump requests to 2.33.0 for security updates [#127](https://github.com/singer-io/tap-bing-ads/pull/127)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.4.0
   * Metadata fields updated for parent streams [#123](https://github.com/singer-io/tap-bing-ads/pull/123)
+  * Python version upgrade to version 3.12 in circleci
 
 # 2.3.3
   * Bump requests to 2.33.0 for security updates [#127](https://github.com/singer-io/tap-bing-ads/pull/127)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='tap-bing-ads',
-    version="2.3.2",
+    version="2.4.0",
     description='Singer.io tap for extracting data from the Bing Ads API',
     author='Stitch',
     url='http://singer.io',

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,8 @@ setup(
         # Seems that suds-community is now the reference for 13.0.11.1 so we can install it now with the removal of use_2to3
         # https://github.com/BingAds/BingAds-Python-SDK/pull/192
         'bingads==13.0.11.1',
-        'requests==2.32.4',
-        'singer-python==6.0.1',
+        'requests==2.34.2',
+        'singer-python==6.8.0',
         'backoff==2.2.1',
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
         'arrow==0.17.0',
         # Seems that suds-community is now the reference for 13.0.11.1 so we can install it now with the removal of use_2to3
         # https://github.com/BingAds/BingAds-Python-SDK/pull/192
-        'bingads==13.0.11.1',
+        'bingads==13.0.28',
         'requests==2.34.2',
         'singer-python==6.8.0',
         'backoff==2.2.1',

--- a/tap_bing_ads/__init__.py
+++ b/tap_bing_ads/__init__.py
@@ -59,6 +59,13 @@ DEFAULT_USER_AGENT = 'Singer.io Bing Ads Tap'
 
 ARRAY_TYPE_REGEX = r'ArrayOf([A-Za-z0-9]+)'
 
+PARENT_MAP = {
+    'campaigns': 'accounts',
+    'ad_groups': 'campaigns',
+    'ads': 'ad_groups',
+    'reports': 'accounts'
+}
+
 def should_retry_httperror(exception):
     """ Return true if exception is required to retry otherwise return false """
     try:
@@ -378,7 +385,14 @@ def get_type_map(client):
 
     return type_map
 
-def get_stream_def(stream_name, schema, stream_metadata=None, pks=None, replication_keys=None):
+def get_stream_def(
+        stream_name,
+        schema,
+        stream_metadata=None,
+        pks=None,
+        replication_keys=None,
+        parent_stream_id=None
+    ):
     '''Generate schema with metadata for the given stream.'''
 
     stream_def = {
@@ -399,6 +413,9 @@ def get_stream_def(stream_name, schema, stream_metadata=None, pks=None, replicat
                 replication_method = 'INCREMENTAL' if replication_keys else 'FULL_TABLE'
             )
         )
+
+    if parent_stream_id:
+        mdata = metadata.write(mdata, (), 'parent-tap-stream-id', parent_stream_id)
 
     # Marking replication key as automatic
     if replication_keys:
@@ -426,31 +443,53 @@ def discover_core_objects():
     core_object_streams = []
 
     LOGGER.info('Initializing CustomerManagementService client - Loading WSDL')
-    client = CustomServiceClient('CustomerManagementService')
-
-    # Load Account's schemas
-    account_schema = get_core_schema(client, 'AdvertiserAccount')
-    core_object_streams.append(
-        # After new standard metadata changes we are getting Id as primary key only
-        # while earlier we were getting Id and LastModifiedTime both because of the coding mistake
-        # but we are writing Id only while writing the schema (func: sync_accounts_stream) in sync mode,
-        # Hence we are keeping ID only in pks.
-        get_stream_def('accounts', account_schema, pks=['Id'], replication_keys=['LastModifiedTime']))
+    customer_client = CustomServiceClient('CustomerManagementService')
 
     LOGGER.info('Initializing CampaignManagementService client - Loading WSDL')
-    client = CustomServiceClient('CampaignManagementService')
+    campaign_client = CustomServiceClient('CampaignManagementService')
 
-    # Load Campaign's schemas
-    campaign_schema = get_core_schema(client, 'Campaign')
-    core_object_streams.append(get_stream_def('campaigns', campaign_schema, pks=['Id']))
+    stream_configs = [
+        {
+            'name': 'accounts',
+            'client': customer_client,
+            'object_type': 'AdvertiserAccount',
+            'pks': ['Id'],
+            'replication_keys': ['LastModifiedTime']
+        },
+        {
+            'name': 'campaigns',
+            'client': campaign_client,
+            'object_type': 'Campaign',
+            'pks': ['Id'],
+        },
+        {
+            'name': 'ad_groups',
+            'client': campaign_client,
+            'object_type': 'AdGroup',
+            'pks': ['Id'],
+        },
+        {
+            'name': 'ads',
+            'client': campaign_client,
+            'object_type': 'Ad',
+            'pks': ['Id'],
+        }
+    ]
 
-    # Load AdGroup's schemas
-    ad_group_schema = get_core_schema(client, 'AdGroup')
-    core_object_streams.append(get_stream_def('ad_groups', ad_group_schema, pks=['Id']))
-
-    # Load Ad's schemas
-    ad_schema = get_core_schema(client, 'Ad')
-    core_object_streams.append(get_stream_def('ads', ad_schema, pks=['Id']))
+    # After new standard metadata changes we are getting Id as primary key only
+    # while earlier we were getting Id and LastModifiedTime both because of the coding mistake
+    # but we are writing Id only while writing the schema (func: sync_accounts_stream) in sync mode,
+    # Hence we are keeping ID only in pks.
+    for config in stream_configs:
+        schema = get_core_schema(config['client'], config['object_type'])
+        stream_def = get_stream_def(
+            config['name'],
+            schema,
+            pks=config['pks'],
+            replication_keys=config.get('replication_keys'),
+            parent_stream_id=PARENT_MAP.get(config['name'])
+        )
+        core_object_streams.append(stream_def)
 
     return core_object_streams
 
@@ -548,6 +587,7 @@ def discover_reports():
     client = CustomServiceClient('ReportingService')
     type_map = get_type_map(client)
     report_column_regex = r'^(?!ArrayOf)(.+Report)Column$'
+    parent_stream_id = PARENT_MAP.get("reports")
 
     for type_name in type_map:
         match = re.match(report_column_regex, type_name)
@@ -559,7 +599,8 @@ def discover_reports():
             report_stream_def = get_stream_def(
                 stream_name,
                 report_schema,
-                stream_metadata=report_metadata)
+                stream_metadata=report_metadata,
+                parent_stream_id=parent_stream_id)
             report_streams.append(report_stream_def)
 
     return report_streams

--- a/tap_bing_ads/__init__.py
+++ b/tap_bing_ads/__init__.py
@@ -114,6 +114,10 @@ class InvalidFieldSelection(Exception):
     (e.g. ImpressionSharePercent). The conflicting field pairs are included in
     the exception message."""
 
+class BingApiError(Exception):
+    """Raised when the Bing Ads API returns an unrecognised OperationError
+    (e.g. InternalError) that does not map to a more specific exception type."""
+
 def log_service_call(service_method, account_id):
     def wrapper(*args, **kwargs): # pylint: disable=inconsistent-return-statements
         log_args = list(map(lambda arg: str(arg).replace('\n', '\\n'), args)) + list(map(lambda kv: '{}={}'.format(*kv), kwargs.items()))
@@ -138,9 +142,9 @@ def log_service_call(service_method, account_id):
                     if any(no_measure_errors):
                         raise NoMeasureSelected(no_measure_errors) from e
                     LOGGER.info('Caught exception for account: %s', account_id)
-                    raise Exception(operation_errors) from e
+                    raise BingApiError(operation_errors) from e
                 if hasattr(e.fault.detail, 'AdApiFaultDetail'):
-                    raise Exception(e.fault.detail.AdApiFaultDetail.Errors) from e
+                    raise BingApiError(e.fault.detail.AdApiFaultDetail.Errors) from e
 
     return wrapper
 
@@ -301,6 +305,8 @@ def get_array_type(array_type):
 
 def get_complex_type_elements(inherited_types, wsdl_type):
     ## inherited type
+    if not wsdl_type.rawchildren or not wsdl_type.rawchildren[0].rawchildren:
+        return []
     if isinstance(wsdl_type.rawchildren[0].rawchildren[0], suds.xsd.sxbasic.Extension): # pylint: disable=no-else-return
         abstract_base = wsdl_type.rawchildren[0].rawchildren[0].ref[0]
         if abstract_base not in inherited_types:
@@ -849,7 +855,7 @@ async def poll_report(client, account_id, report_name, start_date, end_date, req
             # As in the async method backoff does not work directly we created a separate method to handle it.
             response = generate_poll_report(client, request_id)
             if response.Status == 'Error':
-                LOGGER.warn('Error polling %s for account %s with request id %s',
+                LOGGER.warning('Error polling %s for account %s with request id %s',
                             report_name, account_id, request_id)
                 return False, None
             if response.Status == 'Success':
@@ -953,19 +959,24 @@ async def sync_report(client, account_id, report_stream):
                                                  current_start_date,
                                                  current_end_date)
         except InvalidDateRangeEnd as ex: # pylint: disable=unused-variable
-            LOGGER.warn("Bing reported that the requested report date range ended outside of "
+            LOGGER.warning("Bing reported that the requested report date range ended outside of "
                         "their data retention period. Skipping to next range...")
             success = True
         except NoMeasureSelected as ex: # pylint: disable=unused-variable
-            LOGGER.warn("Bing reported that the report request does not include any measure "
+            LOGGER.warning("Bing reported that the report request does not include any measure "
                         "columns. Please select at least one metric field for stream '%s'. "
                         "Skipping report...", report_stream.stream)
             break
         except InvalidFieldSelection as ex: # pylint: disable=unused-variable
-            LOGGER.warn("Stream '%s' has incompatible field selections. "
+            LOGGER.warning("Stream '%s' has incompatible field selections. "
                         "Please deselect conflicting fields. Skipping report...", report_stream.stream)
-            LOGGER.warn(str(ex))
+            LOGGER.warning(str(ex))
             break
+        except BingApiError as ex:
+            LOGGER.warning("Bing API returned an error for stream '%s' between %s and %s. "
+                        "Skipping interval...", report_stream.stream, current_start_date, current_end_date)
+            LOGGER.warning(str(ex))
+            success = True
 
         if success:
             current_start_date = current_end_date.shift(days=1)

--- a/tap_bing_ads/__init__.py
+++ b/tap_bing_ads/__init__.py
@@ -102,6 +102,18 @@ def get_user_agent():
 class InvalidDateRangeEnd(Exception):
     pass
 
+class NoMeasureSelected(Exception):
+    """Raised when a report request contains no measure (metric) columns.
+    Bing Ads requires at least one metric column (e.g. Impressions, Clicks)
+    in addition to dimension columns. Error code: 2017 NoMeasureSelected."""
+
+class InvalidFieldSelection(Exception):
+    """Raised when mutually exclusive fields are both selected for a report stream.
+    Bing Ads defines fieldExclusions groups where certain dimension fields
+    (e.g. DeviceOS, BidMatchType) cannot coexist with share-of-voice metrics
+    (e.g. ImpressionSharePercent). The conflicting field pairs are included in
+    the exception message."""
+
 def log_service_call(service_method, account_id):
     def wrapper(*args, **kwargs): # pylint: disable=inconsistent-return-statements
         log_args = list(map(lambda arg: str(arg).replace('\n', '\\n'), args)) + list(map(lambda kv: '{}={}'.format(*kv), kwargs.items()))
@@ -121,6 +133,10 @@ def log_service_call(service_method, account_id):
                                                      if oe.ErrorCode == 'InvalidCustomDateRangeEnd']
                     if any(invalid_date_range_end_errors):
                         raise InvalidDateRangeEnd(invalid_date_range_end_errors) from e
+                    no_measure_errors = [oe for (_, oe) in operation_errors
+                                         if oe.ErrorCode == 'NoMeasureSelected']
+                    if any(no_measure_errors):
+                        raise NoMeasureSelected(no_measure_errors) from e
                     LOGGER.info('Caught exception for account: %s', account_id)
                     raise Exception(operation_errors) from e
                 if hasattr(e.fault.detail, 'AdApiFaultDetail'):
@@ -142,7 +158,7 @@ class CustomServiceClient(ServiceClient):
     @bing_ads_error_handling
     def __init__(self, name, **kwargs):
         # Initializes a new instance of this ServiceClient class.
-        return super().__init__(name, 'v13', **kwargs)
+        super().__init__(name, 'v13', **kwargs)
 
     def __getattr__(self, name):
         # Log and return service call(suds client call) object
@@ -661,7 +677,7 @@ def get_selected_fields(catalog_item, exclude=None):
 
     # Raise Exception if incompatible fields are selected
     if any(invalid_selections):
-        raise Exception("Invalid selections for field(s) - {{ FieldName: [IncompatibleFields] }}:\n{}".format(json.dumps(invalid_selections, indent=4)))
+        raise InvalidFieldSelection("Invalid selections for field(s) - {{ FieldName: [IncompatibleFields] }}:\n{}".format(json.dumps(invalid_selections, indent=4)))
     return selected_fields
 
 def filter_selected_fields(selected_fields, obj):
@@ -940,6 +956,16 @@ async def sync_report(client, account_id, report_stream):
             LOGGER.warn("Bing reported that the requested report date range ended outside of "
                         "their data retention period. Skipping to next range...")
             success = True
+        except NoMeasureSelected as ex: # pylint: disable=unused-variable
+            LOGGER.warn("Bing reported that the report request does not include any measure "
+                        "columns. Please select at least one metric field for stream '%s'. "
+                        "Skipping report...", report_stream.stream)
+            break
+        except InvalidFieldSelection as ex: # pylint: disable=unused-variable
+            LOGGER.warn("Stream '%s' has incompatible field selections. "
+                        "Please deselect conflicting fields. Skipping report...", report_stream.stream)
+            LOGGER.warn(str(ex))
+            break
 
         if success:
             current_start_date = current_end_date.shift(days=1)

--- a/tap_bing_ads/__init__.py
+++ b/tap_bing_ads/__init__.py
@@ -715,20 +715,21 @@ def sync_accounts_stream(account_ids, catalog_item):
         accounts.append(sobject_to_dict(response))
 
     accounts_bookmark = singer.get_bookmark(STATE, 'accounts', 'last_record')
-    if accounts_bookmark:
-        accounts = list(
-            filter(lambda x: x is not None and x['LastModifiedTime'] >= accounts_bookmark,
-                   accounts))
+    accounts = [
+        acc for acc in accounts
+        if acc is not None and (not accounts_bookmark or acc['LastModifiedTime'] >= accounts_bookmark)
+    ]
 
-    max_accounts_last_modified = max([x['LastModifiedTime'] for x in accounts])
+    max_accounts_last_modified = max([x['LastModifiedTime'] for x in accounts]) if accounts else None
 
     with metrics.record_counter('accounts') as counter:
         # Write only selected fields
         singer.write_records('accounts', filter_selected_fields_many(selected_fields, accounts))
         counter.increment(len(accounts))
 
-    singer.write_bookmark(STATE, 'accounts', 'last_record', max_accounts_last_modified)
-    singer.write_state(STATE)
+    if max_accounts_last_modified:
+        singer.write_bookmark(STATE, 'accounts', 'last_record', max_accounts_last_modified)
+        singer.write_state(STATE)
 
 @bing_ads_error_handling
 def sync_campaigns(client, account_id, selected_streams): # pylint: disable=inconsistent-return-statements

--- a/tests/base_new_framework.py
+++ b/tests/base_new_framework.py
@@ -23,6 +23,7 @@ class BingAdsBaseTest(BaseCase):
     Run discovery for as a prerequisite for most tests
     """
     REQUIRED_KEYS = "required_keys"
+    PARENT_TAP_STREAM_ID = "parent-tap-stream-id"
 
     # respect tap-bing-ads data retention window by looking back a maximum of about 3 years
     start_date = dt.strftime(dt.now() - timedelta(days=365*3), "%Y-%m-%dT00:00:00Z")
@@ -73,7 +74,8 @@ class BingAdsBaseTest(BaseCase):
             BaseCase.PRIMARY_KEYS: set(), # "_sdc_report_datetime" is added by tap
             BaseCase.REPLICATION_METHOD: BaseCase.INCREMENTAL,
             BaseCase.REPLICATION_KEYS: {"TimePeriod"}, # in sync but not in catalog TDL-15816
-            BaseCase.FOREIGN_KEYS: {"AccountId"}
+            BaseCase.FOREIGN_KEYS: {"AccountId"},
+            BingAdsBaseTest.PARENT_TAP_STREAM_ID: "accounts"
         }
         accounts_meta = {
             BaseCase.PRIMARY_KEYS: {"Id"},
@@ -106,18 +108,27 @@ class BingAdsBaseTest(BaseCase):
                                                             'AgeGroup',
                                                             'Gender'}
 
+        campaigns_meta = copy.deepcopy(default)
+        campaigns_meta[BingAdsBaseTest.PARENT_TAP_STREAM_ID] = "accounts"
+
+        adgroups_meta = copy.deepcopy(default)
+        adgroups_meta[BingAdsBaseTest.PARENT_TAP_STREAM_ID] = "campaigns"
+
+        ads_meta = copy.deepcopy(default)
+        ads_meta[BingAdsBaseTest.PARENT_TAP_STREAM_ID] = "ad_groups"
+
         return {
             "accounts": accounts_meta,
             "ad_extension_detail_report": extension_report, # BUG_DOC-1504
             # https://stitchdata.atlassian.net/browse/DOC-1504
             "ad_group_performance_report": default_report, # BUG_DOC-1567
-            "ad_groups": default,
+            "ad_groups": adgroups_meta,
             "ad_performance_report": default_report,
-            "ads": default,
+            "ads": ads_meta,
             "age_gender_audience_report": age_gender_report, # BUG_DOC-1567
             "audience_performance_report": audience_report, # BUG_DOC-1504
             "campaign_performance_report": default_report,
-            "campaigns": default,
+            "campaigns": campaigns_meta,
             "geographic_performance_report": geographic_report,
             "goals_and_funnels_report": goals_report,
             "keyword_performance_report": default_report,
@@ -196,3 +207,12 @@ class BingAdsBaseTest(BaseCase):
         if not stream:
             return auto_fields
         return auto_fields[stream]
+
+    def expected_parent_tap_stream(self, stream=None):
+        """return a dictionary with key of table name and value of parent stream"""
+        parent_stream = {
+            table: properties.get(self.PARENT_TAP_STREAM_ID, None)
+            for table, properties in self.expected_metadata().items()}
+        if not stream:
+            return parent_stream
+        return parent_stream[stream]

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,19 +1,59 @@
 """
 Test tap discovery
 """
-import unittest
 #import re
 #from tap_tester import menagerie, connections, runner
 
 from tap_tester.base_suite_tests.discovery_test import DiscoveryTest
+from tap_tester import menagerie
 from base_new_framework import BingAdsBaseTest
 
 
-class DiscoveryTest(DiscoveryTest,BingAdsBaseTest):
+class DiscoveryTest(DiscoveryTest, BingAdsBaseTest):
     """ Test the tap discovery """
 
     @staticmethod
     def name():
         return "tap_tester_bing_ads_discovery_test"
+
     def streams_to_test(self):
         return self.expected_stream_names()
+
+    def test_parent_stream(self):
+        """
+        Test that each stream's metadata correctly includes the expected parent tap stream ID.
+
+        For each stream in `streams_to_test`, this test:
+        - Retrieves the expected parent tap stream ID from test expectations.
+        - Retrieves the actual metadata from the found catalog.
+        - Verifies that the metadata contains the `PARENT_TAP_STREAM_ID` key (except for the 'accounts' stream).
+        - Confirms that the actual parent tap stream ID matches the expected value.
+        """
+        for stream in self.streams_to_test():
+            with self.subTest(stream=stream):
+                # gather expectations
+                expected_parent_tap_stream_id = self.expected_parent_tap_stream(stream)
+
+                # gather results
+                catalog = [catalog for catalog in self.found_catalogs
+                           if catalog["stream_name"] == stream][0]
+                metadata = menagerie.get_annotated_schema(
+                    self.conn_id, catalog['stream_id'])["metadata"]
+                stream_properties = [item for item in metadata if item.get("breadcrumb") == []]
+                actual_parent_tap_stream_id = \
+                    stream_properties[0].get("metadata", {}).get(self.PARENT_TAP_STREAM_ID, None)
+
+                # verify the metadata key is in properties
+                self.assertIn("metadata", stream_properties[0])
+                stream_metadata = stream_properties[0]["metadata"]
+
+                # For all streams except 'accounts', verify the parent tap stream ID exists and is a string
+                if stream != "accounts":
+                    self.assertIn(self.PARENT_TAP_STREAM_ID, stream_metadata)
+                    self.assertTrue(isinstance(actual_parent_tap_stream_id, str))
+
+                # verify actual parent stream key(s) match expected
+                with self.subTest(msg="validating parent tap stream id"):
+                    self.assertEqual(expected_parent_tap_stream_id, actual_parent_tap_stream_id,
+                                        logging=f"verify {expected_parent_tap_stream_id} "
+                                                f"is saved in metadata as a parent-tap-stream-id")

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -55,5 +55,5 @@ class DiscoveryTest(DiscoveryTest, BingAdsBaseTest):
                 # verify actual parent stream key(s) match expected
                 with self.subTest(msg="validating parent tap stream id"):
                     self.assertEqual(expected_parent_tap_stream_id, actual_parent_tap_stream_id,
-                                        logging=f"verify {expected_parent_tap_stream_id} "
+                                        msg=f"verify {expected_parent_tap_stream_id} "
                                                 f"is saved in metadata as a parent-tap-stream-id")

--- a/tests/unittests/test_backoff_error_handling.py
+++ b/tests/unittests/test_backoff_error_handling.py
@@ -1,4 +1,5 @@
 import unittest
+import asyncio
 import socket
 from datetime import datetime
 from unittest import mock
@@ -1174,7 +1175,7 @@ class TestBackoffError(unittest.TestCase):
            tap_bing_ads.get_type_map(mock_client)
         mock_sleep.assert_called()
 
-    async def test_connection_reset_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
+    def test_connection_reset_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
@@ -1185,10 +1186,10 @@ class TestBackoffError(unittest.TestCase):
         '''
         mock_client = MockClient(ConnectionResetError('Connection reset by peer'))
         with self.assertRaises(OSError):
-            await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
+            asyncio.run(tap_bing_ads.poll_report(mock_client, '', '', '', '', ''))
         mock_sleep.assert_called()
 
-    async def test_socket_timeout_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
+    def test_socket_timeout_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
@@ -1199,10 +1200,10 @@ class TestBackoffError(unittest.TestCase):
         '''
         mock_client = MockClient(socket.timeout())
         with self.assertRaises(socket.timeout):
-           await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
+           asyncio.run(tap_bing_ads.poll_report(mock_client, '', '', '', '', ''))
         mock_sleep.assert_called()
 
-    async def test_http_timeout_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
+    def test_http_timeout_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
                                                         mock_write_schema, mock_get_bookmark, 
                                                         mock_sobject_to_dict, mock_write_state, 
                                                         mock_write_bookmark, mock_metrics, mock_write_records, 
@@ -1214,10 +1215,10 @@ class TestBackoffError(unittest.TestCase):
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 408, 'Request Timeout', {}, f))
         with self.assertRaises(HTTPError):
-            await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
+            asyncio.run(tap_bing_ads.poll_report(mock_client, '', '', '', '', ''))
         mock_sleep.assert_called()
 
-    async def test_internal_server_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
+    def test_internal_server_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
@@ -1229,10 +1230,10 @@ class TestBackoffError(unittest.TestCase):
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 500, 'Internal Server Error', {}, f))
         with self.assertRaises(HTTPError):
-            await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
+            asyncio.run(tap_bing_ads.poll_report(mock_client, '', '', '', '', ''))
         mock_sleep.assert_called()
 
-    async def test_transport_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
+    def test_transport_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
@@ -1243,10 +1244,10 @@ class TestBackoffError(unittest.TestCase):
         '''
         mock_client = MockClient(TransportError('url', 500, 'Internal Server Error'))
         with self.assertRaises(TransportError):
-            await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
+            asyncio.run(tap_bing_ads.poll_report(mock_client, '', '', '', '', ''))
         mock_sleep.assert_called()
 
-    async def test_400_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
+    def test_400_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
@@ -1258,10 +1259,10 @@ class TestBackoffError(unittest.TestCase):
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 400, 'Bad Request', {}, f))
         with self.assertRaises(HTTPError):
-            await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
+            asyncio.run(tap_bing_ads.poll_report(mock_client, '', '', '', '', ''))
         mock_sleep.assert_not_called()
 
-    async def test_url_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
+    def test_url_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
@@ -1273,10 +1274,10 @@ class TestBackoffError(unittest.TestCase):
         mock_client = MockClient(URLError("<urlopen error [Errno 104] Connection reset by peer>"))
 
         with self.assertRaises(URLError):
-            await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
+            asyncio.run(tap_bing_ads.poll_report(mock_client, '', '', '', '', ''))
         mock_sleep.assert_called()
 
-    async def test_ssl_eof_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
+    def test_ssl_eof_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
                                                     mock_write_schema, mock_get_bookmark, 
                                                     mock_sobject_to_dict, mock_write_state, 
                                                     mock_write_bookmark, mock_metrics, mock_write_records, 
@@ -1288,10 +1289,10 @@ class TestBackoffError(unittest.TestCase):
         with open('tests/base.py') as f:
             mock_client = MockClient(ssl.SSLEOFError('EOF occurred in violation of protocol'))
         with self.assertRaises(ssl.SSLEOFError):
-            s = await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
+            asyncio.run(tap_bing_ads.poll_report(mock_client, '', '', '', '', ''))
         mock_sleep.assert_called()
 
-    async def test_exception_408_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
+    def test_exception_408_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
@@ -1303,7 +1304,7 @@ class TestBackoffError(unittest.TestCase):
         mock_client = MockClient(Exception((408, 'Request Timeout')))
 
         with self.assertRaises(Exception):
-            await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
+            asyncio.run(tap_bing_ads.poll_report(mock_client, '', '', '', '', ''))
         mock_sleep.assert_called()
 
     @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            

--- a/tests/unittests/test_backoff_error_handling.py
+++ b/tests/unittests/test_backoff_error_handling.py
@@ -1,11 +1,11 @@
 import unittest
 import socket
+from datetime import datetime
 from unittest import mock
 import tap_bing_ads
 from urllib.error import HTTPError, URLError
 import ssl
 from suds.transport import TransportError
-import datetime
 
 class MockClient():
     '''Mocked ServiceClient class and it's method to pass the test case'''
@@ -42,6 +42,7 @@ class MockClient():
         """ Mocked soap_client to test backoff in get_type_map method"""
         raise self.error
 
+@mock.patch("time.sleep")
 @mock.patch("tap_bing_ads.filter_selected_fields_many", return_value = '')
 @mock.patch("singer.write_records", return_value = '')
 @mock.patch("singer.metrics", return_value = '')
@@ -58,6 +59,25 @@ class TestBackoffError(unittest.TestCase):
     filter_selected_fields_many, write_records , metrics, write_bookmark, write_state, sobject_to_dict,
     get_bookmark, write_schema, get_core_schema, get_selected_fields, time.sleep.
     '''
+
+    def setUp(self):
+        """Patch backoff's datetime so max_time=60 is exceeded after one retry, keeping tests fast."""
+        call_count = {'n': 0}
+        t0 = datetime(2024, 1, 1, 0, 0, 0)
+        t_far = datetime(2024, 1, 1, 0, 1, 10)  # 70 seconds later → elapsed > max_time=60
+
+        def fake_now():
+            call_count['n'] += 1
+            # First two calls: return t0 (start time + first elapsed check = 0s elapsed → keep retrying)
+            # Third call onwards: return t_far (elapsed = 70s > 60 = max_time → give up)
+            if call_count['n'] <= 2:
+                return t0
+            return t_far
+
+        self._datetime_patcher = mock.patch('backoff._sync.datetime')
+        mock_dt = self._datetime_patcher.start()
+        mock_dt.datetime.now.side_effect = fake_now
+        self.addCleanup(self._datetime_patcher.stop)
     @mock.patch("tap_bing_ads.create_sdk_client", return_value = '')
     @mock.patch("tap_bing_ads.CustomServiceClient")
     def test_connection_reset_error_get_account(self, mock_get_account, mock_create_sdk_client,
@@ -65,21 +85,16 @@ class TestBackoffError(unittest.TestCase):
                                                     mock_write_schema, mock_get_bookmark,
                                                     mock_sobject_to_dict, mock_write_state,
                                                     mock_write_bookmark, mock_metrics, mock_write_records,
-                                                    mock_filter_selected_fields_many):
+                                                    mock_filter_selected_fields_many,
+                                                    mock_sleep):
         '''
         Test that tap retry for 60 seconds on the connection reset error.
         '''
-        mock_get_account.side_effect = socket.error(104, 'Connection reset by peer')
-        before_time = datetime.datetime.now()
-        try:
+        mock_get_account.side_effect = ConnectionResetError('Connection reset by peer')
+        with self.assertRaises(OSError):
             tap_bing_ads.sync_accounts_stream(['i1'], {})
-        except ConnectionResetError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
-        
+        mock_sleep.assert_called()
+
     @mock.patch("tap_bing_ads.create_sdk_client", return_value = '')
     @mock.patch("tap_bing_ads.CustomServiceClient")
     def test_socket_timeout__error_get_account(self, mock_get_account, mock_create_sdk_client,
@@ -87,21 +102,16 @@ class TestBackoffError(unittest.TestCase):
                                                     mock_write_schema, mock_get_bookmark,
                                                     mock_sobject_to_dict, mock_write_state,
                                                     mock_write_bookmark, mock_metrics, mock_write_records,
-                                                    mock_filter_selected_fields_many):
+                                                    mock_filter_selected_fields_many,
+                                                    mock_sleep):
         '''
         Test that tap retry for 60 seconds on the socket timeout error.
         '''
         mock_get_account.side_effect = socket.timeout()
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(socket.timeout):
             tap_bing_ads.sync_accounts_stream(['i1'], {})
-        except socket.timeout:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
-        
+        mock_sleep.assert_called()
+
     @mock.patch("tap_bing_ads.create_sdk_client", return_value = '')
     @mock.patch("tap_bing_ads.CustomServiceClient")
     def test_http_timeout__error_get_account(self, mock_get_account, mock_create_sdk_client,
@@ -109,22 +119,17 @@ class TestBackoffError(unittest.TestCase):
                                                     mock_write_schema, mock_get_bookmark,
                                                     mock_sobject_to_dict, mock_write_state,
                                                     mock_write_bookmark, mock_metrics, mock_write_records,
-                                                    mock_filter_selected_fields_many):
+                                                    mock_filter_selected_fields_many,
+                                                    mock_sleep):
         '''
         Test that tap retry for 60 seconds on the http timeout error.
         '''
         with open('tests/base.py') as f:
             mock_get_account.side_effect = HTTPError('url', 408, 'Request Timeout', {}, f)
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(HTTPError):
             tap_bing_ads.sync_accounts_stream(['i1'], {})
-        except HTTPError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
-        
+        mock_sleep.assert_called()
+
     @mock.patch("tap_bing_ads.create_sdk_client", return_value = '')
     @mock.patch("tap_bing_ads.CustomServiceClient")
     def test_internal_server_error_get_account(self, mock_get_account, mock_create_sdk_client,
@@ -132,657 +137,492 @@ class TestBackoffError(unittest.TestCase):
                                                     mock_write_schema, mock_get_bookmark,
                                                     mock_sobject_to_dict, mock_write_state,
                                                     mock_write_bookmark, mock_metrics, mock_write_records,
-                                                    mock_filter_selected_fields_many):
+                                                    mock_filter_selected_fields_many,
+                                                    mock_sleep):
         '''
         Test that tap retry for 60 seconds on the 500 internal server error.
         '''
         with open('tests/base.py') as f:
             mock_get_account.side_effect = HTTPError('url', 500, 'Internal Server Error', {}, f)
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(HTTPError):
             tap_bing_ads.sync_accounts_stream(['i1'], {})
-        except HTTPError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
-        
+        mock_sleep.assert_called()
+
     @mock.patch("tap_bing_ads.create_sdk_client", return_value = '')
     @mock.patch("tap_bing_ads.CustomServiceClient")
     def test_transport_error_get_account(self, mock_get_account, mock_create_sdk_client,
                                                 mock_get_selected_fields, mock_get_core_schema,
                                                 mock_write_schema, mock_get_bookmark,
-                                                mock_sobject_to_dict, mock_write_state, 
-                                                mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                mock_filter_selected_fields_many):
+                                                mock_sobject_to_dict, mock_write_state,
+                                                mock_write_bookmark, mock_metrics, mock_write_records,
+                                                mock_filter_selected_fields_many,
+                                                mock_sleep):
         '''
         Test that tap retry for 60 seconds on the Transport error.
         '''
         mock_get_account.side_effect = TransportError('url', 500, 'Internal Server Error')
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(TransportError):
             tap_bing_ads.sync_accounts_stream(['i1'], {})
-        except TransportError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
-        
+        mock_sleep.assert_called()
+
     @mock.patch("tap_bing_ads.create_sdk_client", return_value = '')
     @mock.patch("tap_bing_ads.CustomServiceClient")
-    def test_400_error_get_account(self, mock_get_account, mock_create_sdk_client, 
-                                        mock_get_selected_fields, mock_get_core_schema, 
-                                        mock_write_schema, mock_get_bookmark, 
-                                        mock_sobject_to_dict, mock_write_state, 
-                                        mock_write_bookmark, mock_metrics, mock_write_records, 
-                                        mock_filter_selected_fields_many):
+    def test_400_error_get_account(self, mock_get_account, mock_create_sdk_client,
+                                        mock_get_selected_fields, mock_get_core_schema,
+                                        mock_write_schema, mock_get_bookmark,
+                                        mock_sobject_to_dict, mock_write_state,
+                                        mock_write_bookmark, mock_metrics, mock_write_records,
+                                        mock_filter_selected_fields_many,
+                                        mock_sleep):
         '''
         Test that tap does not retry on the 400 error.
         '''
         with open('tests/base.py') as f:
             mock_get_account.side_effect = HTTPError('url', 400, 'Bad Request', {}, f)
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(HTTPError):
             tap_bing_ads.sync_accounts_stream(['i1'], {})
-        except HTTPError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code raise error without backoff
-            # time_difference should be less or equal 1 as it directly raise the error without backoff
-            self.assertGreaterEqual(1, time_difference)
+        mock_sleep.assert_not_called()
 
     @mock.patch("tap_bing_ads.create_sdk_client", return_value = '')
     @mock.patch("tap_bing_ads.CustomServiceClient")
-    def test_url_error_get_account(self, mock_get_account, mock_create_sdk_client, 
-                                        mock_get_selected_fields, mock_get_core_schema, 
-                                        mock_write_schema, mock_get_bookmark, 
-                                        mock_sobject_to_dict, mock_write_state, 
-                                        mock_write_bookmark, mock_metrics, mock_write_records, 
-                                        mock_filter_selected_fields_many):
+    def test_url_error_get_account(self, mock_get_account, mock_create_sdk_client,
+                                        mock_get_selected_fields, mock_get_core_schema,
+                                        mock_write_schema, mock_get_bookmark,
+                                        mock_sobject_to_dict, mock_write_state,
+                                        mock_write_bookmark, mock_metrics, mock_write_records,
+                                        mock_filter_selected_fields_many,
+                                        mock_sleep):
         '''
         Test that tap retry for 60 seconds on the URLError.
         '''
         mock_get_account.side_effect  = URLError("<urlopen error [Errno 104] Connection reset by peer>")
-        
-        before_time = datetime.datetime.now()
-        try:
+
+        with self.assertRaises(URLError):
             tap_bing_ads.sync_accounts_stream(['i1'], {})
-        except URLError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
-       
+        mock_sleep.assert_called()
+
     @mock.patch("tap_bing_ads.create_sdk_client", return_value = '')
     @mock.patch("tap_bing_ads.CustomServiceClient")
     def test_ssl_eof_error_get_account(self, mock_get_account, mock_create_sdk_client,
-                                                           mock_get_selected_fields, mock_get_core_schema, 
-                                                           mock_write_schema, mock_get_bookmark, 
-                                                           mock_sobject_to_dict, mock_write_state, 
-                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many):
+                                                           mock_get_selected_fields, mock_get_core_schema,
+                                                           mock_write_schema, mock_get_bookmark,
+                                                           mock_sobject_to_dict, mock_write_state,
+                                                           mock_write_bookmark, mock_metrics, mock_write_records,
+                                                           mock_filter_selected_fields_many,
+                                                           mock_sleep):
         '''
         Test that tap retry for 60 seconds on the SSLEOFError.
         '''
         with open('tests/base.py') as f:
             mock_get_account.side_effect = ssl.SSLEOFError('EOF occurred in violation of protocol')
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(ssl.SSLEOFError):
             tap_bing_ads.sync_accounts_stream(['i1'], {})
-        except ssl.SSLEOFError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
+        mock_sleep.assert_called()
 
     @mock.patch("tap_bing_ads.create_sdk_client", return_value = '')
     @mock.patch("tap_bing_ads.CustomServiceClient")
     def test_exception_408_error_get_account(self, mock_get_account, mock_create_sdk_client,
-                                                           mock_get_selected_fields, mock_get_core_schema, 
-                                                           mock_write_schema, mock_get_bookmark, 
-                                                           mock_sobject_to_dict, mock_write_state, 
-                                                           mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many):
+                                                           mock_get_selected_fields, mock_get_core_schema,
+                                                           mock_write_schema, mock_get_bookmark,
+                                                           mock_sobject_to_dict, mock_write_state,
+                                                           mock_write_bookmark, mock_metrics, mock_write_records,
+                                                           mock_filter_selected_fields_many,
+                                                           mock_sleep):
         '''
         Test that tap retry for 60 seconds on the Exception with error code 408.
         '''
         mock_get_account.side_effect = Exception((408, 'Request Timeout'))
 
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(Exception):
             tap_bing_ads.sync_accounts_stream(['i1'], {})
-        except Exception:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
-        
-    def test_connection_reset_error_sync_campaigns(self, mock_get_selected_fields, mock_get_core_schema, 
-                                                        mock_write_schema, mock_get_bookmark, 
-                                                        mock_sobject_to_dict, mock_write_state, 
-                                                        mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                        mock_filter_selected_fields_many):
+        mock_sleep.assert_called()
+
+    def test_connection_reset_error_sync_campaigns(self, mock_get_selected_fields, mock_get_core_schema,
+                                                        mock_write_schema, mock_get_bookmark,
+                                                        mock_sobject_to_dict, mock_write_state,
+                                                        mock_write_bookmark, mock_metrics, mock_write_records,
+                                                        mock_filter_selected_fields_many,
+                                                        mock_sleep):
         '''
         Test that tap retry for 60 seconds on the connection reset error.
         '''
-        mock_client = MockClient(socket.error(104, 'Connection reset by peer'))
-        before_time = datetime.datetime.now()
-        try:
+        mock_client = MockClient(ConnectionResetError('Connection reset by peer'))
+        with self.assertRaises(OSError):
             tap_bing_ads.sync_campaigns(mock_client, '', [])
-        except ConnectionResetError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
-        
+        mock_sleep.assert_called()
+
     def test_socket_timeout_error_sync_campaigns(self, mock_get_selected_fields, mock_get_core_schema, 
                                                         mock_write_schema, mock_get_bookmark, 
                                                         mock_sobject_to_dict, mock_write_state, 
                                                         mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                        mock_filter_selected_fields_many):
+                                                        mock_filter_selected_fields_many,
+                                                        mock_sleep):
         '''
         Test that tap retry for 60 seconds on the socket timeout error.
         '''
         mock_client = MockClient(socket.timeout())
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(socket.timeout):
             tap_bing_ads.sync_campaigns(mock_client, '', [])
-        except socket.timeout:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
-        
+        mock_sleep.assert_called()
+
     def test_http_timeout_error_sync_campaigns(self, mock_get_selected_fields, mock_get_core_schema, 
                                                     mock_write_schema, mock_get_bookmark, 
                                                     mock_sobject_to_dict, mock_write_state, 
                                                     mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                    mock_filter_selected_fields_many):
+                                                    mock_filter_selected_fields_many,
+                                                    mock_sleep):
         '''
         Test that tap retry for 60 seconds on the http timeout error.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 408, 'Request Timeout', {}, f))
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(HTTPError):
             tap_bing_ads.sync_campaigns(mock_client, '', [])
-        except HTTPError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
-        
+        mock_sleep.assert_called()
+
     def test_internal_server_error_sync_campaigns(self, mock_get_selected_fields, mock_get_core_schema, 
                                                         mock_write_schema, mock_get_bookmark, 
                                                         mock_sobject_to_dict, mock_write_state, 
                                                         mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                        mock_filter_selected_fields_many):
+                                                        mock_filter_selected_fields_many,
+                                                        mock_sleep):
         '''
         Test that tap retry for 60 seconds on the 500 internal server error.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 500, 'Internal Server Error', {}, f))
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(HTTPError):
             tap_bing_ads.sync_campaigns(mock_client, '', [])
-        except HTTPError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
-        
+        mock_sleep.assert_called()
+
     def test_transport_server_error_sync_campaigns(self, mock_get_selected_fields, mock_get_core_schema, 
                                                         mock_write_schema, mock_get_bookmark, 
                                                         mock_sobject_to_dict, mock_write_state, 
                                                         mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                        mock_filter_selected_fields_many):
+                                                        mock_filter_selected_fields_many,
+                                                        mock_sleep):
         mock_client = MockClient(TransportError('url', 500, 'Internal Server Error'))
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(TransportError):
             tap_bing_ads.sync_campaigns(mock_client, '', [])
-        except TransportError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
-        
+        mock_sleep.assert_called()
+
     def test_400_error_sync_campaigns(self, mock_get_selected_fields, mock_get_core_schema, 
                                             mock_write_schema, mock_get_bookmark, 
                                             mock_sobject_to_dict, mock_write_state, 
                                             mock_write_bookmark, mock_metrics, mock_write_records, 
-                                            mock_filter_selected_fields_many):
+                                            mock_filter_selected_fields_many,
+                                            mock_sleep):
         '''
         Test that tap does not retry on the 400 error.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 400, 'Bad Request', {}, f))
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(HTTPError):
             tap_bing_ads.sync_campaigns(mock_client, '', [])
-        except HTTPError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code raise error without backoff
-            # time_difference should be less or equal 1 as it directly raise the error without backoff
-            self.assertGreaterEqual(1, time_difference)
-    
+        mock_sleep.assert_not_called()
+
     def test_url_error_sync_campaigns(self, mock_get_selected_fields, mock_get_core_schema, 
                                                         mock_write_schema, mock_get_bookmark, 
                                                         mock_sobject_to_dict, mock_write_state, 
                                                         mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                        mock_filter_selected_fields_many):
+                                                        mock_filter_selected_fields_many,
+                                                        mock_sleep):
         mock_client = MockClient(URLError("<urlopen error [Errno 104] Connection reset by peer>"))
-        
-        before_time = datetime.datetime.now()
-        try:
+
+        with self.assertRaises(URLError):
             tap_bing_ads.sync_campaigns(mock_client, '', [])
-        except URLError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
+        mock_sleep.assert_called()
 
     def test_ssl_eof_error_sync_campaigns(self, mock_get_selected_fields, mock_get_core_schema, 
                                                 mock_write_schema, mock_get_bookmark, 
                                                 mock_sobject_to_dict, mock_write_state, 
                                                 mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                mock_filter_selected_fields_many):
+                                                mock_filter_selected_fields_many,
+                                                mock_sleep):
         '''
         Test that tap retry for 60 seconds on the SSLEOFError.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(ssl.SSLEOFError('EOF occurred in violation of protocol'))
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(ssl.SSLEOFError):
             tap_bing_ads.sync_campaigns(mock_client, '', [])
-        except ssl.SSLEOFError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
+        mock_sleep.assert_called()
 
     def test_exception_408_sync_campaigns(self, mock_get_selected_fields, mock_get_core_schema, 
                                                         mock_write_schema, mock_get_bookmark, 
                                                         mock_sobject_to_dict, mock_write_state, 
                                                         mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                        mock_filter_selected_fields_many):
+                                                        mock_filter_selected_fields_many,
+                                                        mock_sleep):
         mock_client = MockClient(Exception((408, 'Request Timeout')))
-        
-        before_time = datetime.datetime.now()
-        try:
+
+        with self.assertRaises(Exception):
             tap_bing_ads.sync_campaigns(mock_client, '', [])
-        except Exception:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
+        mock_sleep.assert_called()
 
     def test_connection_reset_error_sync_ad_groups(self, mock_get_selected_fields, mock_get_core_schema, 
                                                         mock_write_schema, mock_get_bookmark, 
                                                         mock_sobject_to_dict, mock_write_state, 
                                                         mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                        mock_filter_selected_fields_many):
+                                                        mock_filter_selected_fields_many,
+                                                        mock_sleep):
         '''
         Test that tap retry for 60 seconds on the connection reset error.
         '''
-        mock_client = MockClient(socket.error(104, 'Connection reset by peer'))
-        before_time = datetime.datetime.now()
-        try:
+        mock_client = MockClient(ConnectionResetError('Connection reset by peer'))
+        with self.assertRaises(OSError):
             tap_bing_ads.sync_ad_groups(mock_client, '', ['dummy_campaign_id'], [])
-        except ConnectionResetError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
-        
+        mock_sleep.assert_called()
+
     def test_socket_timeout_error_sync_ad_groups(self, mock_get_selected_fields, mock_get_core_schema, 
                                                         mock_write_schema, mock_get_bookmark, 
                                                         mock_sobject_to_dict, mock_write_state, 
                                                         mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                        mock_filter_selected_fields_many):
+                                                        mock_filter_selected_fields_many,
+                                                        mock_sleep):
         '''
         Test that tap retry for 60 seconds on the socket timeout error.
         '''
         mock_client = MockClient(socket.timeout())
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(socket.timeout):
             tap_bing_ads.sync_ad_groups(mock_client, '', ['dummy_campaign_id'], [])
-        except socket.timeout:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
-        
+        mock_sleep.assert_called()
+
     def test_http_timeout_error_sync_ad_groups(self, mock_get_selected_fields, mock_get_core_schema, 
                                                     mock_write_schema, mock_get_bookmark, 
                                                     mock_sobject_to_dict, mock_write_state, 
                                                     mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                    mock_filter_selected_fields_many):
+                                                    mock_filter_selected_fields_many,
+                                                    mock_sleep):
         '''
         Test that tap retry for 60 seconds on the http timeout error.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 408, 'Request Timeout', {}, f))
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(HTTPError):
             tap_bing_ads.sync_ad_groups(mock_client, '', ['dummy_campaign_id'], [])
-        except HTTPError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
-        
+        mock_sleep.assert_called()
+
     def test_internal_server_error_sync_ad_groups(self, mock_get_selected_fields, mock_get_core_schema, 
                                                         mock_write_schema, mock_get_bookmark, 
                                                         mock_sobject_to_dict, mock_write_state, 
                                                         mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                        mock_filter_selected_fields_many):
+                                                        mock_filter_selected_fields_many,
+                                                        mock_sleep):
         '''
         Test that tap retry for 60 seconds on the 500 internal server error.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 500, 'Internal Server Error', {}, f))
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(HTTPError):
             tap_bing_ads.sync_ad_groups(mock_client, '', ['dummy_campaign_id'], [])
-        except HTTPError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
-        
+        mock_sleep.assert_called()
+
     def test_transport_error_sync_ad_groups(self, mock_get_selected_fields, mock_get_core_schema, 
                                                         mock_write_schema, mock_get_bookmark, 
                                                         mock_sobject_to_dict, mock_write_state, 
                                                         mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                        mock_filter_selected_fields_many):
+                                                        mock_filter_selected_fields_many,
+                                                        mock_sleep):
         '''
         Test that tap retry for 60 seconds on the Transport error.
         '''
         mock_client = MockClient(TransportError('url', 500, 'Internal Server Error'))
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(TransportError):
             tap_bing_ads.sync_ad_groups(mock_client, '', ['dummy_campaign_id'], [])
-        except TransportError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
-        
+        mock_sleep.assert_called()
+
     def test_400_error_sync_ad_groups(self, mock_get_selected_fields, mock_get_core_schema, 
                                                         mock_write_schema, mock_get_bookmark, 
                                                         mock_sobject_to_dict, mock_write_state, 
                                                         mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                        mock_filter_selected_fields_many):
+                                                        mock_filter_selected_fields_many,
+                                                        mock_sleep):
         '''
         Test that tap does not retry on the 400 error.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 400, 'Bad Request', {}, f))
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(HTTPError):
             tap_bing_ads.sync_ad_groups(mock_client, '', ['dummy_campaign_id'], [])
-        except HTTPError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code raise error without backoff
-            # time_difference should be less or equal 1 as it directly raise the error without backoff
-            self.assertGreaterEqual(1, time_difference)
+        mock_sleep.assert_not_called()
 
     def test_url_error_sync_ad_groups(self, mock_get_selected_fields, mock_get_core_schema, 
                                                         mock_write_schema, mock_get_bookmark, 
                                                         mock_sobject_to_dict, mock_write_state, 
                                                         mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                        mock_filter_selected_fields_many):
+                                                        mock_filter_selected_fields_many,
+                                                        mock_sleep):
         '''
         Test that tap retry for 60 seconds on the URLError.
         '''
         mock_client = MockClient(URLError("<urlopen error [Errno 104] Connection reset by peer>"))
-        
-        before_time = datetime.datetime.now()
-        try:
+
+        with self.assertRaises(URLError):
             tap_bing_ads.sync_ad_groups(mock_client, '', ['dummy_campaign_id'], [])
-        except URLError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
- 
+        mock_sleep.assert_called()
+
     def test_ssl_eof_error_sync_ad_groups(self, mock_get_selected_fields, mock_get_core_schema, 
                                                 mock_write_schema, mock_get_bookmark, 
                                                 mock_sobject_to_dict, mock_write_state, 
                                                 mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                mock_filter_selected_fields_many):
+                                                mock_filter_selected_fields_many,
+                                                mock_sleep):
         '''
         Test that tap retry for 60 seconds on the SSLEOFError.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(ssl.SSLEOFError('EOF occurred in violation of protocol'))
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(ssl.SSLEOFError):
             tap_bing_ads.sync_ad_groups(mock_client, '', ['dummy_campaign_id'], [])
-        except ssl.SSLEOFError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)        
+        mock_sleep.assert_called()
 
     def test_exception_408_sync_ad_groups(self, mock_get_selected_fields, mock_get_core_schema, 
                                                         mock_write_schema, mock_get_bookmark, 
                                                         mock_sobject_to_dict, mock_write_state, 
                                                         mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                        mock_filter_selected_fields_many):
+                                                        mock_filter_selected_fields_many,
+                                                        mock_sleep):
         '''
         Test that tap retry for 60 seconds on the Exception with error code 408.
         '''
         mock_client = MockClient(Exception((408, 'Request Timeout')))
-        
-        before_time = datetime.datetime.now()
-        try:
+
+        with self.assertRaises(Exception):
             tap_bing_ads.sync_ad_groups(mock_client, '', ['dummy_campaign_id'], [])
-        except Exception:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
+        mock_sleep.assert_called()
 
     def test_connection_reset_error_sync_ads(self, mock_get_selected_fields, mock_get_core_schema, 
                                                 mock_write_schema, mock_get_bookmark, 
                                                 mock_sobject_to_dict, mock_write_state, 
                                                 mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                mock_filter_selected_fields_many):
+                                                mock_filter_selected_fields_many,
+                                                mock_sleep):
         '''
         Test that tap retry for 60 seconds on the connection reset error.
         '''
-        mock_client = MockClient(socket.error(104, 'Connection reset by peer'))
-        before_time = datetime.datetime.now()
-        try:
+        mock_client = MockClient(ConnectionResetError('Connection reset by peer'))
+        with self.assertRaises(OSError):
             tap_bing_ads.sync_ads(mock_client, ['dummy_stream'], ['dummy_ad_id'])
-        except ConnectionResetError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
-        
+        mock_sleep.assert_called()
+
     def test_socket_timeout_error_sync_ads(self, mock_get_selected_fields, mock_get_core_schema, 
                                                 mock_write_schema, mock_get_bookmark, 
                                                 mock_sobject_to_dict, mock_write_state, 
                                                 mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                mock_filter_selected_fields_many):
+                                                mock_filter_selected_fields_many,
+                                                mock_sleep):
         '''
         Test that tap retry for 60 seconds on the socket timeout error.
         '''
         mock_client = MockClient(socket.timeout())
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(socket.timeout):
             tap_bing_ads.sync_ads(mock_client, ['dummy_stream'], ['dummy_ad_id'])
-        except socket.timeout:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
-        
+        mock_sleep.assert_called()
+
     def test_http_timeout_error_sync_ads(self, mock_get_selected_fields, mock_get_core_schema, 
                                                 mock_write_schema, mock_get_bookmark, 
                                                 mock_sobject_to_dict, mock_write_state, 
                                                 mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                smock_filter_selected_fields_many):
+                                                mock_filter_selected_fields_many,
+                                                mock_sleep):
         '''
         Test that tap retry for 60 seconds on the http timeout error.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 408, 'Request Timeout', {}, f))
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(HTTPError):
             tap_bing_ads.sync_ads(mock_client, ['dummy_stream'], ['dummy_ad_id'])
-        except HTTPError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
-        
+        mock_sleep.assert_called()
+
     def test_internal_server_error_sync_ads(self, mock_get_selected_fields, mock_get_core_schema, 
                                                 mock_write_schema, mock_get_bookmark, 
                                                 mock_sobject_to_dict, mock_write_state, 
                                                 mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                mock_filter_selected_fields_many):
+                                                mock_filter_selected_fields_many,
+                                                mock_sleep):
         '''
         Test that tap retry for 60 seconds on the 500 internal server error.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 500, 'Internal Server Error', {}, f))
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(HTTPError):
             tap_bing_ads.sync_ads(mock_client, ['dummy_stream'], ['dummy_ad_id'])
-        except HTTPError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)        
+        mock_sleep.assert_called()
 
     def test_transport_error_sync_ads(self, mock_get_selected_fields, mock_get_core_schema, 
                                                 mock_write_schema, mock_get_bookmark, 
                                                 mock_sobject_to_dict, mock_write_state, 
                                                 mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                mock_filter_selected_fields_many):
+                                                mock_filter_selected_fields_many,
+                                                mock_sleep):
         '''
         Test that tap retry for 60 seconds on the Transport error.
         '''
         mock_client = MockClient(TransportError('url', 500, 'Internal Server Error'))
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(TransportError):
             tap_bing_ads.sync_ads(mock_client, ['dummy_stream'], ['dummy_ad_id'])
-        except TransportError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60) 
+        mock_sleep.assert_called()
 
     def test_400_error_sync_ads(self, mock_get_selected_fields, mock_get_core_schema, 
                                                 mock_write_schema, mock_get_bookmark, 
                                                 mock_sobject_to_dict, mock_write_state, 
                                                 mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                mock_filter_selected_fields_many):
+                                                mock_filter_selected_fields_many,
+                                                mock_sleep):
         '''
         Test that tap does not retry on the 400 error.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 400, 'Bad Request', {}, f))
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(HTTPError):
             tap_bing_ads.sync_ads(mock_client, ['dummy_stream'], ['dummy_ad_id'])
-        except HTTPError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code raise error without backoff
-            # time_difference should be less or equal 1 as it directly raise the error without backoff
-            self.assertGreaterEqual(1, time_difference)
+        mock_sleep.assert_not_called()
 
     def test_url_error_sync_ads(self, mock_get_selected_fields, mock_get_core_schema, 
                                                 mock_write_schema, mock_get_bookmark, 
                                                 mock_sobject_to_dict, mock_write_state, 
                                                 mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                mock_filter_selected_fields_many):
+                                                mock_filter_selected_fields_many,
+                                                mock_sleep):
         '''
         Test that tap retry for 60 seconds on the URLError.
         '''
         mock_client = MockClient(URLError("<urlopen error [Errno 104] Connection reset by peer>"))
-        
-        before_time = datetime.datetime.now()
-        try:
+
+        with self.assertRaises(URLError):
             tap_bing_ads.sync_ads(mock_client, ['dummy_stream'], ['dummy_ad_id'])
-        except URLError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60) 
+        mock_sleep.assert_called()
 
     def test_ssl_eof_error_sync_ads(self, mock_get_selected_fields, mock_get_core_schema, 
                                         mock_write_schema, mock_get_bookmark, 
                                         mock_sobject_to_dict, mock_write_state, 
                                         mock_write_bookmark, mock_metrics, mock_write_records, 
-                                        mock_filter_selected_fields_many):
+                                        mock_filter_selected_fields_many,
+                                        mock_sleep):
         '''
         Test that tap retry for 60 seconds on the SSLEOFError.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(ssl.SSLEOFError('EOF occurred in violation of protocol'))
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(ssl.SSLEOFError):
             tap_bing_ads.sync_ads(mock_client, ['dummy_stream'], ['dummy_ad_id'])
-        except ssl.SSLEOFError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)  
+        mock_sleep.assert_called()
 
     def test_exception_408_sync_ads(self, mock_get_selected_fields, mock_get_core_schema, 
                                                 mock_write_schema, mock_get_bookmark, 
                                                 mock_sobject_to_dict, mock_write_state, 
                                                 mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                mock_filter_selected_fields_many):
+                                                mock_filter_selected_fields_many,
+                                                mock_sleep):
         '''
         Test that tap retry for 60 seconds on the Exception with error code 408.
         '''
         mock_client = MockClient(Exception((408, 'Request Timeout')))
-        
-        before_time = datetime.datetime.now()
-        try:
+
+        with self.assertRaises(Exception):
             tap_bing_ads.sync_ads(mock_client, ['dummy_stream'], ['dummy_ad_id'])
-        except Exception:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60) 
+        mock_sleep.assert_called()
 
     @mock.patch("tap_bing_ads.build_report_request")
     def test_connection_reset_error_get_report_request_id(self, mock_build_report_request, 
@@ -790,906 +630,681 @@ class TestBackoffError(unittest.TestCase):
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many):
+                                                           mock_filter_selected_fields_many,
+                                                           mock_sleep):
         '''
         Test that tap retry for 60 seconds on the connection reset error.
         '''
-        mock_client = MockClient(socket.error(104, 'Connection reset by peer'))
-        before_time = datetime.datetime.now()
-        try:
+        mock_client = MockClient(ConnectionResetError('Connection reset by peer'))
+        with self.assertRaises(OSError):
             tap_bing_ads.get_report_request_id(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date', 'dummy_start_key',
                                                 force_refresh = True)
-        except ConnectionResetError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
-        
+        mock_sleep.assert_called()
+
     @mock.patch("tap_bing_ads.build_report_request")
     def test_socket_timeout_error_get_report_request_id(self, mock_build_report_request, 
                                                            mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many):
+                                                           mock_filter_selected_fields_many,
+                                                           mock_sleep):
         mock_client = MockClient(socket.timeout())
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(socket.timeout):
            tap_bing_ads.get_report_request_id(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date', 'dummy_start_key', 
                                               force_refresh = True)
-        except socket.timeout:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
-        
+        mock_sleep.assert_called()
+
     @mock.patch("tap_bing_ads.build_report_request")
     def test_http_timeout_error_get_report_request_id(self, mock_build_report_request, 
                                                            mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many):
+                                                           mock_filter_selected_fields_many,
+                                                           mock_sleep):
         '''
         Test that tap retry for 60 seconds on the http timeout error.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 408, 'Request Timeout', {}, f))
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(HTTPError):
             tap_bing_ads.get_report_request_id(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date', 'dummy_start_key',
                                                force_refresh = True)
-        except HTTPError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
-     
-    @mock.patch("tap_bing_ads.build_report_request")   
+        mock_sleep.assert_called()
+
+    @mock.patch("tap_bing_ads.build_report_request")
     def test_internal_server_error_get_report_request_id(self, mock_build_report_request,
                                                            mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many):
+                                                           mock_filter_selected_fields_many,
+                                                           mock_sleep):
         '''
         Test that tap retry for 60 seconds on the 500 internal server error.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 500, 'Internal Server Error', {}, f))
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(HTTPError):
             tap_bing_ads.get_report_request_id(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date', 'dummy_start_key',
                                                force_refresh = True)
-        except HTTPError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
+        mock_sleep.assert_called()
 
-    @mock.patch("tap_bing_ads.build_report_request")   
+    @mock.patch("tap_bing_ads.build_report_request")
     def test_transport_error_get_report_request_id(self, mock_build_report_request,
                                                            mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many):
+                                                           mock_filter_selected_fields_many,
+                                                           mock_sleep):
         '''
         Test that tap retry for 60 seconds on the Transport error.
         '''
         mock_client = MockClient(TransportError('url', 500, 'Internal Server Error'))
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(TransportError):
             tap_bing_ads.get_report_request_id(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date', 'dummy_start_key',
                                                force_refresh = True)
-        except TransportError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
-        
-    @mock.patch("tap_bing_ads.build_report_request")   
+        mock_sleep.assert_called()
+
+    @mock.patch("tap_bing_ads.build_report_request")
     def test_400_error_get_report_request_id(self, mock_build_report_request,
                                                            mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many):
+                                                           mock_filter_selected_fields_many,
+                                                           mock_sleep):
         '''
         Test that tap does not retry on the 400 error.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 400, 'Bad Request', {}, f))
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(HTTPError):
             tap_bing_ads.get_report_request_id(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date', 'dummy_start_key',
                                                force_refresh = True)
-        except HTTPError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code raise error without backoff
-            # time_difference should be less or equal 1 as it directly raise the error without backoff
-            self.assertGreaterEqual(1, time_difference)
+        mock_sleep.assert_not_called()
 
-    @mock.patch("tap_bing_ads.build_report_request")   
+    @mock.patch("tap_bing_ads.build_report_request")
     def test_url_error_get_report_request_id(self, mock_build_report_request,
                                                            mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many):
+                                                           mock_filter_selected_fields_many,
+                                                           mock_sleep):
         '''
         Test that tap retry for 60 seconds on the URLError.
         '''
         mock_client = MockClient(URLError("<urlopen error [Errno 104] Connection reset by peer>"))
-        
-        before_time = datetime.datetime.now()
-        try:
+
+        with self.assertRaises(URLError):
             tap_bing_ads.get_report_request_id(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date', 'dummy_start_key',
                                                force_refresh = True)
-        except URLError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
-    
-    @mock.patch("tap_bing_ads.build_report_request")   
+        mock_sleep.assert_called()
+
+    @mock.patch("tap_bing_ads.build_report_request")
     def test_ssl_eof_error_get_report_request_id(self, mock_build_report_request,
                                                            mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many):
+                                                           mock_filter_selected_fields_many,
+                                                           mock_sleep):
         '''
         Test that tap retry for 60 seconds on the SSLEOFError.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(ssl.SSLEOFError('EOF occurred in violation of protocol'))
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(ssl.SSLEOFError):
             tap_bing_ads.get_report_request_id(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date', 'dummy_start_key',
                                                force_refresh = True)
-        except ssl.SSLEOFError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
+        mock_sleep.assert_called()
 
-    @mock.patch("tap_bing_ads.build_report_request")   
+    @mock.patch("tap_bing_ads.build_report_request")
     def test_url_error_get_report_request_id(self, mock_build_report_request,
                                                            mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many):
+                                                           mock_filter_selected_fields_many,
+                                                           mock_sleep):
         '''
         Test that tap retry for 60 seconds on the Exception with error code 408.
         '''
         mock_client = MockClient(Exception((408, 'Request Timeout')))
-        
-        before_time = datetime.datetime.now()
-        try:
+
+        with self.assertRaises(Exception):
             tap_bing_ads.get_report_request_id(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date', 'dummy_start_key',
                                                force_refresh = True)
-        except Exception:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
+        mock_sleep.assert_called()
 
     def test_connection_reset_error_build_report_request(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many):
+                                                           mock_filter_selected_fields_many,
+                                                           mock_sleep):
         '''
         Test that tap retry for 60 seconds on the connection reset error.
         '''
-        mock_client = MockClient(socket.error(104, 'Connection reset by peer'))
-        before_time = datetime.datetime.now()
-        try:
+        mock_client = MockClient(ConnectionResetError('Connection reset by peer'))
+        with self.assertRaises(OSError):
             tap_bing_ads.build_report_request(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date')
-        except ConnectionResetError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
-        
+        mock_sleep.assert_called()
+
     def test_socket_timeout_error_build_report_request(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many):
+                                                           mock_filter_selected_fields_many,
+                                                           mock_sleep):
         '''
         Test that tap retry for 60 seconds on the socket timeout error.
         '''
         mock_client = MockClient(socket.timeout())
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(socket.timeout):
            tap_bing_ads.build_report_request(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date')
-        except socket.timeout:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
-        
+        mock_sleep.assert_called()
+
     def test_http_timeout_error_build_report_request(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many):
+                                                           mock_filter_selected_fields_many,
+                                                           mock_sleep):
         '''
         Test that tap retry for 60 seconds on the http timeout error.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 408, 'Request Timeout', {}, f))
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(HTTPError):
             tap_bing_ads.build_report_request(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date')
-        except HTTPError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
-     
+        mock_sleep.assert_called()
+
     def test_internal_server_error_build_report_request(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many):
+                                                           mock_filter_selected_fields_many,
+                                                           mock_sleep):
         '''
         Test that tap retry for 60 seconds on the 500 internal server error.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 500, 'Internal Server Error', {}, f))
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(HTTPError):
             tap_bing_ads.build_report_request(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date')
-        except HTTPError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
-        
+        mock_sleep.assert_called()
+
     def test_transport_error_build_report_request(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many):
+                                                           mock_filter_selected_fields_many,
+                                                           mock_sleep):
         '''
         Test that tap retry for 60 seconds on the Transport error.
         '''
         mock_client = MockClient(TransportError('url', 500, 'Internal Server Error'))
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(TransportError):
             tap_bing_ads.build_report_request(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date')
-        except TransportError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
-        
+        mock_sleep.assert_called()
+
     def test_400_error_build_report_request(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many):
+                                                           mock_filter_selected_fields_many,
+                                                           mock_sleep):
         '''
         Test that tap does not retry on the 400 error.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 400, 'Bad Request', {}, f))
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(HTTPError):
             tap_bing_ads.build_report_request(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date')
-        except HTTPError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code raise error without backoff
-            # time_difference should be less or equal 1 as it directly raise the error without backoff
-            self.assertGreaterEqual(1, time_difference)
+        mock_sleep.assert_not_called()
 
     def test_url_error_build_report_request(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many):
+                                                           mock_filter_selected_fields_many,
+                                                           mock_sleep):
         '''
         Test that tap retry for 60 seconds on the URLError.
         '''
         mock_client = MockClient(URLError("<urlopen error [Errno 104] Connection reset by peer>"))
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(URLError):
             tap_bing_ads.build_report_request(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date')
-        except URLError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)   
-    
+        mock_sleep.assert_called()
+
     def test_ssl_eof_error_build_report_request(self, mock_get_selected_fields, mock_get_core_schema, 
                                                     mock_write_schema, mock_get_bookmark, 
                                                     mock_sobject_to_dict, mock_write_state, 
                                                     mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                    mock_filter_selected_fields_many):
+                                                    mock_filter_selected_fields_many,
+                                                    mock_sleep):
         '''
         Test that tap retry for 60 seconds on the SSLEOFError.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(ssl.SSLEOFError('EOF occurred in violation of protocol'))
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(ssl.SSLEOFError):
             tap_bing_ads.build_report_request(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date')
-        except ssl.SSLEOFError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
+        mock_sleep.assert_called()
 
     def test_408_exception_build_report_request(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many):
+                                                           mock_filter_selected_fields_many,
+                                                           mock_sleep):
         '''
         Test that tap retry for 60 seconds on the Exception with error code 408.
         '''
         mock_client = MockClient(Exception((408, 'Request Timeout')))
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(Exception):
             tap_bing_ads.build_report_request(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date')
-        except Exception:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)  
+        mock_sleep.assert_called()
 
     def test_connection_reset_error_get_report_schema(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many):
+                                                           mock_filter_selected_fields_many,
+                                                           mock_sleep):
         '''
         Test that tap retry for 60 seconds on the connection reset error.
         '''
-        mock_client = MockClient(socket.error(104, 'Connection reset by peer'))
-        before_time = datetime.datetime.now()
-        try:
+        mock_client = MockClient(ConnectionResetError('Connection reset by peer'))
+        with self.assertRaises(OSError):
             tap_bing_ads.get_report_schema(mock_client, '')
-        except ConnectionResetError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
-        
+        mock_sleep.assert_called()
+
     def test_socket_timeout_error_get_report_schema(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many):
+                                                           mock_filter_selected_fields_many,
+                                                           mock_sleep):
         '''
         Test that tap retry for 60 seconds on the socket timeout error.
         '''
         mock_client = MockClient(socket.timeout())
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(socket.timeout):
            tap_bing_ads.get_report_schema(mock_client, '')
-        except socket.timeout:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
-        
+        mock_sleep.assert_called()
+
     def test_http_timeout_error_get_report_schema(self, mock_get_selected_fields, mock_get_core_schema, 
                                                         mock_write_schema, mock_get_bookmark, 
                                                         mock_sobject_to_dict, mock_write_state, 
                                                         mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                        mock_filter_selected_fields_many):
+                                                        mock_filter_selected_fields_many,
+                                                        mock_sleep):
         '''
         Test that tap retry for 60 seconds on the http timeout error.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 408, 'Request Timeout', {}, f))
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(HTTPError):
             tap_bing_ads.get_report_schema(mock_client, '')
-        except HTTPError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
-     
+        mock_sleep.assert_called()
+
     def test_internal_server_error_get_report_schema(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many):
+                                                           mock_filter_selected_fields_many,
+                                                           mock_sleep):
         '''
         Test that tap retry for 60 seconds on the 500 internal server error.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 500, 'Internal Server Error', {}, f))
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(HTTPError):
             tap_bing_ads.get_report_schema(mock_client, '')
-        except HTTPError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
+        mock_sleep.assert_called()
 
     def test_transport_error_get_report_schema(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many):
+                                                           mock_filter_selected_fields_many,
+                                                           mock_sleep):
         '''
         Test that tap retry for 60 seconds on the Transport error.
         '''
         mock_client = MockClient(TransportError('url', 500, 'Internal Server Error'))
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(TransportError):
             tap_bing_ads.get_report_schema(mock_client, '')
-        except TransportError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
+        mock_sleep.assert_called()
 
     def test_400_error_get_report_schema(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many):
+                                                           mock_filter_selected_fields_many,
+                                                           mock_sleep):
         '''
         Test that tap does not retry on the 400 error.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 400, 'Bad Request', {}, f))
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(HTTPError):
             tap_bing_ads.get_report_schema(mock_client, '')
-        except HTTPError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code raise error without backoff
-            # time_difference should be less or equal 1 as it directly raise the error without backoff
-            self.assertGreaterEqual(1, time_difference)
+        mock_sleep.assert_not_called()
 
     def test_url_error_get_report_schema(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many):
+                                                           mock_filter_selected_fields_many,
+                                                           mock_sleep):
         '''
         Test that tap retry for 60 seconds on the Transport error.
         '''
         mock_client = MockClient(URLError("<urlopen error [Errno 104] Connection reset by peer>"))
-        
-        before_time = datetime.datetime.now()
-        try:
+
+        with self.assertRaises(URLError):
             tap_bing_ads.get_report_schema(mock_client, '')
-        except URLError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
-    
+        mock_sleep.assert_called()
+
     def test_ssl_eof_error_get_report_schema(self, mock_get_selected_fields, mock_get_core_schema, 
                                                 mock_write_schema, mock_get_bookmark, 
                                                 mock_sobject_to_dict, mock_write_state, 
                                                 mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                mock_filter_selected_fields_many):
+                                                mock_filter_selected_fields_many,
+                                                mock_sleep):
         '''
         Test that tap retry for 60 seconds on the SSLEOFError.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(ssl.SSLEOFError('EOF occurred in violation of protocol'))
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(ssl.SSLEOFError):
             tap_bing_ads.get_report_schema(mock_client, '')
-        except ssl.SSLEOFError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
-    
+        mock_sleep.assert_called()
+
     def test_exception_408_get_report_schema(self, mock_get_selected_fields, mock_get_core_schema, 
                                                 mock_write_schema, mock_get_bookmark, 
                                                 mock_sobject_to_dict, mock_write_state, 
                                                 mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                mock_filter_selected_fields_many):
+                                                mock_filter_selected_fields_many,
+                                                mock_sleep):
         '''
         Test that tap retry for 60 seconds on the Exception with error code 408.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(Exception((408, 'Request Timeout')))
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(Exception):
             tap_bing_ads.get_report_schema(mock_client, '')
-        except Exception:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
+        mock_sleep.assert_called()
 
-                
+
     def test_connection_reset_error_get_type_map(self, mock_get_selected_fields, mock_get_core_schema, 
                                                     mock_write_schema, mock_get_bookmark, 
                                                     mock_sobject_to_dict, mock_write_state, 
                                                     mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                    mock_filter_selected_fields_many):
+                                                    mock_filter_selected_fields_many,
+                                                    mock_sleep):
         '''
         Test that tap retry for 60 seconds on the connection reset error.
         '''
-        mock_client = MockClient(socket.error(104, 'Connection reset by peer'))
-        before_time = datetime.datetime.now()
-        try:
+        mock_client = MockClient(ConnectionResetError('Connection reset by peer'))
+        with self.assertRaises(OSError):
             tap_bing_ads.get_type_map(mock_client)
-        except ConnectionResetError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
-        
+        mock_sleep.assert_called()
+
     def test_socket_timeout_error_get_type_map(self, mock_get_selected_fields, mock_get_core_schema, 
                                                     mock_write_schema, mock_get_bookmark, 
                                                     mock_sobject_to_dict, mock_write_state, 
                                                     mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                    mock_filter_selected_fields_many):
+                                                    mock_filter_selected_fields_many,
+                                                    mock_sleep):
         '''
         Test that tap retry for 60 seconds on the socket timeout error.
         '''
         mock_client = MockClient(socket.timeout())
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(socket.timeout):
            tap_bing_ads.get_type_map(mock_client)
-        except socket.timeout:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
-        
+        mock_sleep.assert_called()
+
     def test_http_timeout_error_get_type_map(self, mock_get_selected_fields, mock_get_core_schema, 
                                                 mock_write_schema, mock_get_bookmark, 
                                                 mock_sobject_to_dict, mock_write_state, 
                                                 mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                mock_filter_selected_fields_many):
+                                                mock_filter_selected_fields_many,
+                                                mock_sleep):
         '''
         Test that tap retry for 60 seconds on the http timeout error.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 408, 'Request Timeout', {}, f))
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(HTTPError):
             tap_bing_ads.get_type_map(mock_client)
-        except HTTPError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
-     
+        mock_sleep.assert_called()
+
     def test_internal_server_error_get_type_map(self, mock_get_selected_fields, mock_get_core_schema, 
                                                     mock_write_schema, mock_get_bookmark, 
                                                     mock_sobject_to_dict, mock_write_state, 
                                                     mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                    mock_filter_selected_fields_many):
+                                                    mock_filter_selected_fields_many,
+                                                    mock_sleep):
         '''
         Test that tap retry for 60 seconds on the 500 internal server error.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 500, 'Internal Server Error', {}, f))
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(HTTPError):
             tap_bing_ads.get_type_map(mock_client)
-        except HTTPError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
+        mock_sleep.assert_called()
 
     def test_transport_error_get_type_map(self, mock_get_selected_fields, mock_get_core_schema, 
                                                     mock_write_schema, mock_get_bookmark, 
                                                     mock_sobject_to_dict, mock_write_state, 
                                                     mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                    mock_filter_selected_fields_many):
+                                                    mock_filter_selected_fields_many,
+                                                    mock_sleep):
         '''
         Test that tap retry for 60 seconds on the Transport error.
         '''
         mock_client = MockClient(TransportError('url', 500, 'Internal Server Error'))
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(TransportError):
             tap_bing_ads.get_type_map(mock_client)
-        except TransportError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
-        
+        mock_sleep.assert_called()
+
     def test_400_error_get_type_map(self, mock_get_selected_fields, mock_get_core_schema, 
                                                     mock_write_schema, mock_get_bookmark, 
                                                     mock_sobject_to_dict, mock_write_state, 
                                                     mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                    mock_filter_selected_fields_many):
+                                                    mock_filter_selected_fields_many,
+                                                    mock_sleep):
         '''
         Test that tap does not retry on the 400 error.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 400, 'Bad Request', {}, f))
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(HTTPError):
             tap_bing_ads.get_type_map(mock_client)
-        except HTTPError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code raise error without backoff
-            # time_difference should be less or equal 1 as it directly raise the error without backoff
-            self.assertGreaterEqual(1, time_difference)
+        mock_sleep.assert_not_called()
 
     def test_url_error_get_type_map(self, mock_get_selected_fields, mock_get_core_schema, 
                                                     mock_write_schema, mock_get_bookmark, 
                                                     mock_sobject_to_dict, mock_write_state, 
                                                     mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                    mock_filter_selected_fields_many):
+                                                    mock_filter_selected_fields_many,
+                                                    mock_sleep):
         '''
         Test that tap retry for 60 seconds on the URLError.
         '''
         mock_client = MockClient(URLError("<urlopen error [Errno 104] Connection reset by peer>"))
-        
-        before_time = datetime.datetime.now()
-        try:
+
+        with self.assertRaises(URLError):
             tap_bing_ads.get_type_map(mock_client)
-        except URLError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
-   
+        mock_sleep.assert_called()
+
     def test_ssl_eof_error_get_type_map(self, mock_get_selected_fields, mock_get_core_schema, 
                                             mock_write_schema, mock_get_bookmark, 
                                             mock_sobject_to_dict, mock_write_state, 
                                             mock_write_bookmark, mock_metrics, mock_write_records, 
-                                            mock_filter_selected_fields_many):
+                                            mock_filter_selected_fields_many,
+                                            mock_sleep):
         '''
         Test that tap retry for 60 seconds on the SSLEOFError.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(ssl.SSLEOFError('EOF occurred in violation of protocol'))
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(ssl.SSLEOFError):
             tap_bing_ads.get_type_map(mock_client)
-        except ssl.SSLEOFError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
+        mock_sleep.assert_called()
 
     def test_exception_408_get_type_map(self, mock_get_selected_fields, mock_get_core_schema, 
                                                     mock_write_schema, mock_get_bookmark, 
                                                     mock_sobject_to_dict, mock_write_state, 
                                                     mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                    mock_filter_selected_fields_many):
+                                                    mock_filter_selected_fields_many,
+                                                    mock_sleep):
         '''
         Test that tap retry for 60 seconds on the Exception with error code 408.
         '''
         mock_client = MockClient(Exception((408, 'Request Timeout')))
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(Exception):
            tap_bing_ads.get_type_map(mock_client)
-        except Exception:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
+        mock_sleep.assert_called()
 
     async def test_connection_reset_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many):
+                                                           mock_filter_selected_fields_many,
+                                                           mock_sleep):
         '''
         Test that tap retry for 60 seconds on the connection reset error.
         '''
-        mock_client = MockClient(socket.error(104, 'Connection reset by peer'))
-        before_time = datetime.datetime.now()
-        try:
+        mock_client = MockClient(ConnectionResetError('Connection reset by peer'))
+        with self.assertRaises(OSError):
             await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
-        except ConnectionResetError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
-        
+        mock_sleep.assert_called()
+
     async def test_socket_timeout_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many):
+                                                           mock_filter_selected_fields_many,
+                                                           mock_sleep):
         '''
         Test that tap retry for 60 seconds on the socket timeout error.
         '''
         mock_client = MockClient(socket.timeout())
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(socket.timeout):
            await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
-        except socket.timeout:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
-        
+        mock_sleep.assert_called()
+
     async def test_http_timeout_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
                                                         mock_write_schema, mock_get_bookmark, 
                                                         mock_sobject_to_dict, mock_write_state, 
                                                         mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                        mock_filter_selected_fields_many):
+                                                        mock_filter_selected_fields_many,
+                                                        mock_sleep):
         '''
         Test that tap retry for 60 seconds on the http timeout error.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 408, 'Request Timeout', {}, f))
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(HTTPError):
             await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
-        except HTTPError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
-     
+        mock_sleep.assert_called()
+
     async def test_internal_server_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many):
+                                                           mock_filter_selected_fields_many,
+                                                           mock_sleep):
         '''
         Test that tap retry for 60 seconds on the 500 internal server error.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 500, 'Internal Server Error', {}, f))
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(HTTPError):
             await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
-        except HTTPError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
-            
+        mock_sleep.assert_called()
+
     async def test_transport_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many):
+                                                           mock_filter_selected_fields_many,
+                                                           mock_sleep):
         '''
         Test that tap retry for 60 seconds on the Transport error.
         '''
         mock_client = MockClient(TransportError('url', 500, 'Internal Server Error'))
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(TransportError):
             await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
-        except TransportError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
-        
+        mock_sleep.assert_called()
+
     async def test_400_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many):
+                                                           mock_filter_selected_fields_many,
+                                                           mock_sleep):
         '''
         Test that tap does not retry on the 400 error.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(HTTPError('url', 400, 'Bad Request', {}, f))
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(HTTPError):
             await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
-        except HTTPError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code raise error without backoff
-            # time_difference should be less or equal 1 as it directly raise the error without backoff
-            self.assertGreaterEqual(1, time_difference)
+        mock_sleep.assert_not_called()
 
     async def test_url_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many):
+                                                           mock_filter_selected_fields_many,
+                                                           mock_sleep):
         '''
         Test that tap retry for 60 seconds on the URLError.
         '''
         mock_client = MockClient(URLError("<urlopen error [Errno 104] Connection reset by peer>"))
-        
-        before_time = datetime.datetime.now()
-        try:
+
+        with self.assertRaises(URLError):
             await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
-        except URLError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
+        mock_sleep.assert_called()
 
     async def test_ssl_eof_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
                                                     mock_write_schema, mock_get_bookmark, 
                                                     mock_sobject_to_dict, mock_write_state, 
                                                     mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                    mock_filter_selected_fields_many):
+                                                    mock_filter_selected_fields_many,
+                                                    mock_sleep):
         '''
         Test that tap retry for 60 seconds on the SSLEOFError.
         '''
         with open('tests/base.py') as f:
             mock_client = MockClient(ssl.SSLEOFError('EOF occurred in violation of protocol'))
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(ssl.SSLEOFError):
             s = await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
-        except ssl.SSLEOFError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
+        mock_sleep.assert_called()
 
     async def test_exception_408_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many):
+                                                           mock_filter_selected_fields_many,
+                                                           mock_sleep):
         '''
         Test that tap retry for 60 seconds on the Exception with error code 408.
         '''
         mock_client = MockClient(Exception((408, 'Request Timeout')))
-        
-        before_time = datetime.datetime.now()
-        try:
+
+        with self.assertRaises(Exception):
             await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
-        except Exception:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
+        mock_sleep.assert_called()
 
     @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
     @mock.patch("bingads.OAuthWebAuthCodeGrant.request_oauth_tokens_by_refresh_token")
@@ -1700,19 +1315,14 @@ class TestBackoffError(unittest.TestCase):
                                                         mock_write_schema, mock_get_bookmark, 
                                                         mock_sobject_to_dict, mock_write_state, 
                                                         mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                        mock_filter_selected_fields_many):
+                                                        mock_filter_selected_fields_many,
+                                                        mock_sleep):
         mock_oauth.return_value = ''
-        mock_client.side_effect = socket.error(104, 'Connection reset by peer')
-        before_time = datetime.datetime.now()
-        try:
+        mock_client.side_effect = ConnectionResetError('Connection reset by peer')
+        with self.assertRaises(OSError):
             tap_bing_ads.create_sdk_client('dummy_service', {})
-        except ConnectionResetError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
-        
+        mock_sleep.assert_called()
+
     @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
     @mock.patch("bingads.OAuthWebAuthCodeGrant.request_oauth_tokens_by_refresh_token")
     @mock.patch("bingads.AuthorizationData", return_value = '')
@@ -1722,22 +1332,17 @@ class TestBackoffError(unittest.TestCase):
                                                     mock_write_schema, mock_get_bookmark, 
                                                     mock_sobject_to_dict, mock_write_state, 
                                                     mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                    mock_filter_selected_fields_many):
+                                                    mock_filter_selected_fields_many,
+                                                    mock_sleep):
         '''
         Test that tap retry for 60 seconds on the socket timeout error.
         '''
         mock_oauth.return_value = ''
         mock_client.side_effect = socket.timeout()
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(socket.timeout):
             tap_bing_ads.create_sdk_client('dummy_service', {})
-        except socket.timeout:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
-        
+        mock_sleep.assert_called()
+
     @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
     @mock.patch("bingads.OAuthWebAuthCodeGrant.request_oauth_tokens_by_refresh_token")
     @mock.patch("bingads.AuthorizationData", return_value = '')
@@ -1747,23 +1352,18 @@ class TestBackoffError(unittest.TestCase):
                                                         mock_write_schema, mock_get_bookmark, 
                                                         mock_sobject_to_dict, mock_write_state, 
                                                         mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                        mock_filter_selected_fields_many):
+                                                        mock_filter_selected_fields_many,
+                                                        mock_sleep):
         '''
         Test that tap retry for 60 seconds on the http timeout error.
         '''
         mock_oauth.return_value = ''
         with open('tests/base.py') as f:
             mock_client.side_effect = HTTPError('url', 408, 'Request Timeout', {}, f)
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(HTTPError):
             tap_bing_ads.create_sdk_client('dummy_service', {})
-        except HTTPError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
-        
+        mock_sleep.assert_called()
+
     @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
     @mock.patch("bingads.OAuthWebAuthCodeGrant.request_oauth_tokens_by_refresh_token")
     @mock.patch("bingads.AuthorizationData", return_value = '')
@@ -1773,23 +1373,18 @@ class TestBackoffError(unittest.TestCase):
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many):
+                                                           mock_filter_selected_fields_many,
+                                                           mock_sleep):
         '''
         Test that tap retry for 60 seconds on the 500 internal server error.
         '''
         mock_oauth.return_value = ''
         with open('tests/base.py') as f:
             mock_client.side_effect = HTTPError('url', 500, 'Internal Server Error', {}, f)
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(HTTPError):
             tap_bing_ads.create_sdk_client('dummy_service', {})
-        except HTTPError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
-        
+        mock_sleep.assert_called()
+
     @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
     @mock.patch("bingads.OAuthWebAuthCodeGrant.request_oauth_tokens_by_refresh_token")
     @mock.patch("bingads.AuthorizationData", return_value = '')
@@ -1799,22 +1394,17 @@ class TestBackoffError(unittest.TestCase):
                                                     mock_write_schema, mock_get_bookmark, 
                                                     mock_sobject_to_dict, mock_write_state, 
                                                     mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                    mock_filter_selected_fields_many):
+                                                    mock_filter_selected_fields_many,
+                                                    mock_sleep):
         '''
         Test that tap retry for 60 seconds on the Transport error.
         '''
         mock_oauth.return_value = ''
         mock_client.side_effect = TransportError('url', 500, 'Internal Server Error')
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(TransportError):
             tap_bing_ads.create_sdk_client('dummy_service', {})
-        except TransportError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
-        
+        mock_sleep.assert_called()
+
     @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
     @mock.patch("bingads.OAuthWebAuthCodeGrant.request_oauth_tokens_by_refresh_token")
     @mock.patch("bingads.AuthorizationData", return_value = '')
@@ -1824,24 +1414,19 @@ class TestBackoffError(unittest.TestCase):
                                                 mock_write_schema, mock_get_bookmark, 
                                                 mock_sobject_to_dict, mock_write_state, 
                                                 mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                mock_filter_selected_fields_many):
+                                                mock_filter_selected_fields_many,
+                                                mock_sleep):
         '''
         Test that tap does not retry on the 400 error.
         '''
         mock_oauth.return_value = ''
         with open('tests/base.py') as f:
             mock_client.side_effect = HTTPError('url', 400, 'Bad Request', {}, f)
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(HTTPError):
             tap_bing_ads.create_sdk_client('dummy_service', {})
-        except HTTPError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code raise error without backoff
-            # time_difference should be less or equal 1 as it directly raise the error without backoff
-            self.assertGreaterEqual(1, time_difference)
-        
-        
+        mock_sleep.assert_not_called()
+
+
     @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
     @mock.patch("bingads.OAuthWebAuthCodeGrant.request_oauth_tokens_by_refresh_token")
     @mock.patch("bingads.AuthorizationData", return_value = '')
@@ -1851,22 +1436,17 @@ class TestBackoffError(unittest.TestCase):
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many):
+                                                           mock_filter_selected_fields_many,
+                                                           mock_sleep):
         '''
         Test that tap retry for 60 seconds on the SSLEOFError.
         '''
         mock_oauth.return_value = ''
         with open('tests/base.py') as f:
             mock_client.side_effect = ssl.SSLEOFError('EOF occurred in violation of protocol')
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(ssl.SSLEOFError):
             tap_bing_ads.create_sdk_client('dummy_service', {})
-        except ssl.SSLEOFError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
+        mock_sleep.assert_called()
 
     @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
     @mock.patch("bingads.OAuthWebAuthCodeGrant.request_oauth_tokens_by_refresh_token")
@@ -1877,22 +1457,17 @@ class TestBackoffError(unittest.TestCase):
                                                     mock_write_schema, mock_get_bookmark, 
                                                     mock_sobject_to_dict, mock_write_state, 
                                                     mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                    mock_filter_selected_fields_many):
+                                                    mock_filter_selected_fields_many,
+                                                    mock_sleep):
         '''
         Test that tap retry for 60 seconds on the Transport error.
         '''
         mock_oauth.return_value = ''
         mock_client.side_effect = URLError("<urlopen error [Errno 104] Connection reset by peer>")
-        
-        before_time = datetime.datetime.now()
-        try:
+
+        with self.assertRaises(URLError):
             tap_bing_ads.create_sdk_client('dummy_service', {})
-        except URLError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
+        mock_sleep.assert_called()
 
     @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
     @mock.patch("bingads.OAuthWebAuthCodeGrant.request_oauth_tokens_by_refresh_token")
@@ -1903,19 +1478,14 @@ class TestBackoffError(unittest.TestCase):
                                                     mock_write_schema, mock_get_bookmark, 
                                                     mock_sobject_to_dict, mock_write_state, 
                                                     mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                    mock_filter_selected_fields_many):
+                                                    mock_filter_selected_fields_many,
+                                                    mock_sleep):
         '''
         Test that tap retry for 60 seconds on the Exception with error code 408.
         '''
         mock_oauth.return_value = ''
         mock_client.side_effect = Exception((408, 'Request Timeout'))
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(Exception):
             tap_bing_ads.create_sdk_client('dummy_service', {})
-        except Exception:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
+        mock_sleep.assert_called()
 

--- a/tests/unittests/test_request_timeout.py
+++ b/tests/unittests/test_request_timeout.py
@@ -1,4 +1,5 @@
 import unittest
+import asyncio
 from datetime import datetime
 from unittest import mock
 
@@ -212,7 +213,7 @@ class TestBackoffError(unittest.TestCase):
             tap_bing_ads.get_report_schema(mock_client, '')
         mock_sleep.assert_called()
 
-    async def test_url_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
+    def test_url_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
@@ -223,7 +224,7 @@ class TestBackoffError(unittest.TestCase):
         '''
         mock_client = MockClient(URLError('_ssl.c:1059: The handshake operation timed out'))
         with self.assertRaises(URLError):
-            await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
+            asyncio.run(tap_bing_ads.poll_report(mock_client, '', '', '', '', ''))
         mock_sleep.assert_called()
 
     @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            

--- a/tests/unittests/test_request_timeout.py
+++ b/tests/unittests/test_request_timeout.py
@@ -1,12 +1,12 @@
 import unittest
+from datetime import datetime
 from unittest import mock
 
 from requests.exceptions import Timeout
 import tap_bing_ads
 from urllib.error import URLError
 from tap_bing_ads import CustomServiceClient
-import datetime
-    
+
 class MockClient():
     '''Mocked ServiceClient class and it's method to pass the test case'''
     def __init__(self, error):
@@ -60,6 +60,7 @@ class MockClient():
         '''Mocked call_count property of the Client class'''
         return self.count
 
+@mock.patch("time.sleep")
 @mock.patch("tap_bing_ads.filter_selected_fields_many", return_value = '')
 @mock.patch("singer.write_records", return_value = '')
 @mock.patch("singer.metrics", return_value = '')
@@ -76,6 +77,23 @@ class TestBackoffError(unittest.TestCase):
     filter_selected_fields_many, write_records , metrics, write_bookmark, write_state, sobject_to_dict,
     get_bookmark, write_schema, get_core_schema, get_selected_fields, time.sleep.
     '''
+
+    def setUp(self):
+        """Patch backoff's datetime so max_time=60 is exceeded after one retry, keeping tests fast."""
+        call_count = {'n': 0}
+        t0 = datetime(2024, 1, 1, 0, 0, 0)
+        t_far = datetime(2024, 1, 1, 0, 1, 10)  # 70 seconds later
+
+        def fake_now():
+            call_count['n'] += 1
+            if call_count['n'] <= 2:
+                return t0
+            return t_far
+
+        self._datetime_patcher = mock.patch('backoff._sync.datetime')
+        mock_dt = self._datetime_patcher.start()
+        mock_dt.datetime.now.side_effect = fake_now
+        self.addCleanup(self._datetime_patcher.stop)
     @mock.patch("tap_bing_ads.create_sdk_client", return_value = '')
     @mock.patch("tap_bing_ads.CustomServiceClient")
     def test_url_error_get_account(self, mock_get_account, mock_create_sdk_client,
@@ -83,77 +101,57 @@ class TestBackoffError(unittest.TestCase):
                                                     mock_write_schema, mock_get_bookmark,
                                                     mock_sobject_to_dict, mock_write_state,
                                                     mock_write_bookmark, mock_metrics, mock_write_records,
-                                                    mock_filter_selected_fields_many):
+                                                    mock_filter_selected_fields_many,
+                                                    mock_sleep):
         '''
         Test that tap retry on the url timeout error for 60 seconds.
         '''
         mock_get_account.side_effect = URLError('_ssl.c:1059: The handshake operation timed out')
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(URLError):
             tap_bing_ads.sync_accounts_stream(['i1'], {})
-        except URLError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
+        mock_sleep.assert_called()
 
     def test_url_error_sync_campaigns(self, mock_get_selected_fields, mock_get_core_schema, 
                                                         mock_write_schema, mock_get_bookmark, 
                                                         mock_sobject_to_dict, mock_write_state, 
                                                         mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                        mock_filter_selected_fields_many):
+                                                        mock_filter_selected_fields_many,
+                                                        mock_sleep):
         '''
         Test that tap retry on the timeout error for 1 minute.
         '''
         mock_client = MockClient(URLError('_ssl.c:1059: The handshake operation timed out'))
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(URLError):
             tap_bing_ads.sync_campaigns(mock_client, '', [])
-        except URLError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
+        mock_sleep.assert_called()
 
     def test_url_error_sync_ad_groups(self, mock_get_selected_fields, mock_get_core_schema, 
                                                         mock_write_schema, mock_get_bookmark, 
                                                         mock_sobject_to_dict, mock_write_state, 
                                                         mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                        mock_filter_selected_fields_many):
+                                                        mock_filter_selected_fields_many,
+                                                        mock_sleep):
         '''
         Test that tap retry on the timeout error for 1 minute.
         '''
         mock_client = MockClient(URLError('_ssl.c:1059: The handshake operation timed out'))
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(URLError):
             tap_bing_ads.sync_ad_groups(mock_client, '', ['dummy_campaign_id'], [])
-        except URLError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
+        mock_sleep.assert_called()
 
     def test_url_error_sync_ads(self, mock_get_selected_fields, mock_get_core_schema, 
                                                 mock_write_schema, mock_get_bookmark, 
                                                 mock_sobject_to_dict, mock_write_state, 
                                                 mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                mock_filter_selected_fields_many):
+                                                mock_filter_selected_fields_many,
+                                                mock_sleep):
         '''
         Test that tap retry on the timeout error for 1 minute.
         '''
         mock_client = MockClient(URLError('_ssl.c:1059: The handshake operation timed out'))
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(URLError):
             tap_bing_ads.sync_ads(mock_client, ['dummy_stream'], ['dummy_ad_id'])
-        except URLError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60) 
+        mock_sleep.assert_called() 
 
     @mock.patch("tap_bing_ads.build_report_request")
     def test_url_error_get_report_request_id(self, mock_build_report_request, 
@@ -161,97 +159,72 @@ class TestBackoffError(unittest.TestCase):
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many):
+                                                           mock_filter_selected_fields_many,
+                                                           mock_sleep):
         '''
         Test that tap retry on the timeout error for 1 minute.
         '''
         mock_client = MockClient(URLError('_ssl.c:1059: The handshake operation timed out'))
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(URLError):
             tap_bing_ads.get_report_request_id(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date', 'dummy_start_key',
                                                 force_refresh = True)
-        except URLError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
+        mock_sleep.assert_called()
 
     def test_url_error_build_report_request(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many):
+                                                           mock_filter_selected_fields_many,
+                                                           mock_sleep):
         '''
         Test that tap retry on the timeout error for 1 minute.
         '''
         mock_client = MockClient(URLError('_ssl.c:1059: The handshake operation timed out'))
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(URLError):
             tap_bing_ads.build_report_request(mock_client, '', '', '', 'dummy_start_date', 'dumy_end_date')
-        except URLError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
+        mock_sleep.assert_called()
 
     def test_url_error_get_type_map(self, mock_get_selected_fields, mock_get_core_schema, 
                                                     mock_write_schema, mock_get_bookmark, 
                                                     mock_sobject_to_dict, mock_write_state, 
                                                     mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                    mock_filter_selected_fields_many):
+                                                    mock_filter_selected_fields_many,
+                                                    mock_sleep):
         '''
         Test that tap retry on the timeout error for 1 minute.
         '''
         mock_client = MockClient(URLError('_ssl.c:1059: The handshake operation timed out'))
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(URLError):
             tap_bing_ads.get_type_map(mock_client)
-        except URLError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
+        mock_sleep.assert_called()
 
     def test_url_error_get_report_schema(self, mock_get_selected_fields, mock_get_core_schema, 
                                                     mock_write_schema, mock_get_bookmark, 
                                                     mock_sobject_to_dict, mock_write_state, 
                                                     mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                    mock_filter_selected_fields_many):
+                                                    mock_filter_selected_fields_many,
+                                                    mock_sleep):
         '''
         Test that tap retry on the timeout error for 1 minute.
         '''
         mock_client = MockClient(URLError('_ssl.c:1059: The handshake operation timed out'))
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(URLError):
             tap_bing_ads.get_report_schema(mock_client, '')
-        except URLError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
+        mock_sleep.assert_called()
 
     async def test_url_error_poll_report(self, mock_get_selected_fields, mock_get_core_schema, 
                                                            mock_write_schema, mock_get_bookmark, 
                                                            mock_sobject_to_dict, mock_write_state, 
                                                            mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                           mock_filter_selected_fields_many):
+                                                           mock_filter_selected_fields_many,
+                                                           mock_sleep):
         '''
         Test that tap retry on the timeout error for 1 minute.
         '''
         mock_client = MockClient(URLError('_ssl.c:1059: The handshake operation timed out'))
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(URLError):
             await tap_bing_ads.poll_report(mock_client, '', '', '', '', '')
-        except URLError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
+        mock_sleep.assert_called()
 
     @mock.patch("tap_bing_ads.CONFIG", return_value = {'oauth_client_id': '', 'oauth_client_secret': '', 'refresh_token': ''})            
     @mock.patch("bingads.OAuthWebAuthCodeGrant.request_oauth_tokens_by_refresh_token")
@@ -262,28 +235,24 @@ class TestBackoffError(unittest.TestCase):
                                                         mock_write_schema, mock_get_bookmark, 
                                                         mock_sobject_to_dict, mock_write_state, 
                                                         mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                        mock_filter_selected_fields_many):
+                                                        mock_filter_selected_fields_many,
+                                                        mock_sleep):
         '''
         Test that tap retry on the timeout error for 1 minute.
         '''
         mock_oauth.return_value = ''
         mock_client.side_effect = URLError('_ssl.c:1059: The handshake operation timed out')
-        before_time = datetime.datetime.now()
-        try:
+        with self.assertRaises(URLError):
             tap_bing_ads.create_sdk_client('dummy_service', {})
-        except URLError:
-            after_time = datetime.datetime.now()
-            time_difference = (after_time - before_time).total_seconds()
-            # verify the code backed off for 60 seconds
-            # time_difference should be greater or equal 60 as some time elapsed while calculating `after_time`
-            self.assertGreaterEqual(time_difference, 60)
+        mock_sleep.assert_called()
 
     @mock.patch('tap_bing_ads.requests.Session.get')
     def test_timeout_error_stream_report(self, mocked_get, mock_get_selected_fields, mock_get_core_schema, 
                                                         mock_write_schema, mock_get_bookmark, 
                                                         mock_sobject_to_dict, mock_write_state, 
                                                         mock_write_bookmark, mock_metrics, mock_write_records, 
-                                                        mock_filter_selected_fields_many):
+                                                        mock_filter_selected_fields_many,
+                                                        mock_sleep):
         '''
         Test that tap retry on the timeout error for 5 times.
         '''
@@ -294,7 +263,7 @@ class TestBackoffError(unittest.TestCase):
             # verify that the request backoffs for 5 times in case of Timeout error
             self.assertEqual(mocked_get.call_count, 5)
 
-# Mock Client 
+# Mock Client
 class MockedClient():
     def __init__(self) -> None:
         pass
@@ -315,7 +284,7 @@ class Args():
 @mock.patch("tap_bing_ads.CustomServiceClient")
 class TestRequestTimeoutValue(unittest.TestCase):
     def test_default_value_request_timeout(self, mock_client, mock_set_options, mock_authorization_data, mock_oauth, mocked_args):
-        """ 
+        """
             Unit tests to ensure that request timeout is set based default value
         """
         tap_bing_ads.CONFIG = {}
@@ -327,9 +296,9 @@ class TestRequestTimeoutValue(unittest.TestCase):
         service_client = CustomServiceClient('CustomerManagementService')
         service_client.set_options(**kwargs)
         mock_set_options.assert_called_with(headers={'User-Agent': 'Singer.io Bing Ads Tap'}, timeout=300.0)
-    
+
     def test_config_provided_request_timeout(self, mock_client, mock_set_options, mock_authorization_data, mock_oauth, mocked_args):
-        """ 
+        """
             Unit tests to ensure that request timeout is set based on config value
         """
         tap_bing_ads.CONFIG = {}
@@ -343,7 +312,7 @@ class TestRequestTimeoutValue(unittest.TestCase):
         mock_set_options.assert_called_with(headers={'User-Agent': 'Singer.io Bing Ads Tap'}, timeout=100.0)
 
     def test_float_config_provided_request_timeout(self, mock_client, mock_set_options, mock_authorization_data, mock_oauth, mocked_args):
-        """ 
+        """
             Unit tests to ensure that request timeout is set based on config float value
         """
         tap_bing_ads.CONFIG = {}
@@ -355,9 +324,9 @@ class TestRequestTimeoutValue(unittest.TestCase):
         service_client = CustomServiceClient('CustomerManagementService')
         service_client.set_options(**kwargs)
         mock_set_options.assert_called_with(headers={'User-Agent': 'Singer.io Bing Ads Tap'}, timeout=100.8)
-    
+
     def test_string_config_provided_request_timeout(self, mock_client, mock_set_options, mock_authorization_data, mock_oauth, mocked_args):
-        """ 
+        """
             Unit tests to ensure that request timeout is set based on config string value
         """
         tap_bing_ads.CONFIG = {}
@@ -369,9 +338,9 @@ class TestRequestTimeoutValue(unittest.TestCase):
         service_client = CustomServiceClient('CustomerManagementService')
         service_client.set_options(**kwargs)
         mock_set_options.assert_called_with(headers={'User-Agent': 'Singer.io Bing Ads Tap'}, timeout=100.0)
-    
+
     def test_empty_config_provided_request_timeout(self, mock_client, mock_set_options, mock_authorization_data, mock_oauth, mocked_args):
-        """ 
+        """
             Unit tests to ensure that request timeout is set based on default value if empty value is given in config
         """
         tap_bing_ads.CONFIG = {}

--- a/tests/unittests/test_stream_def.py
+++ b/tests/unittests/test_stream_def.py
@@ -4,14 +4,16 @@ from tap_bing_ads import get_stream_def
 
 class TestStreamDef(unittest.TestCase):
     """A set of unit tests to ensure that we are getting proper schema and metadata for each streams"""
-    
+
     # Mocking metadata
     def mock_metadata(*args):
         return {(): {'table-key-properties': ['Id'], 'forced-replication-method': 'INCREMENTAL', 'valid-replication-keys': 'LastModifiedTime', 'inclusion': 'available'}, ('properties', 'BillToCustomerId'): {'inclusion': 'available'}, ('properties', 'CurrencyCode'): {'inclusion': 'available', 'fieldExclusions': [['properties', 'BidMatchType'], ['properties', 'DeviceOS'], ['properties', 'Goal'], ['properties', 'GoalType'], ['properties', 'TopVsOther']]}, ('properties', 'AccountFinancialStatus'): {'inclusion': 'available'}, ('properties', 'Id'): {'inclusion': 'automatic'}, ('properties', 'Language'): {'inclusion': 'available'}, ('properties', 'LastModifiedByUserId'): {'inclusion': 'available'}, ('properties', 'LastModifiedTime'): {'inclusion': 'available'}, ('properties', 'Name'): {'inclusion': 'available'}}
 
     # Mocking metadata.write method
     def mock_write(mdata,tpl,incl='inclusion', val='automatic'):
-        if isinstance(tpl[1],list):
+        if not tpl:
+            mdata[tpl] = {incl: val}
+        elif isinstance(tpl[1],list):
             mdata[(tpl[0],tpl[1][0])] = {incl: val}
         else:
             mdata[tpl] = {incl: val}
@@ -26,7 +28,7 @@ class TestStreamDef(unittest.TestCase):
     @mock.patch("singer.metadata.write", side_effect=mock_write)
     @mock.patch("singer.metadata.to_list", side_effect=mock_to_list)
     def test_get_stream_def_for_account_stream(self,mock_to_list,mock_write,mock_metadata, mock_get_standard_metadata):
-        """ 
+        """
         Call get_stream_def function for a stream and validate primary keys, automatic keys and replication keys assignment
         """
         # Defined mock variables to call get_stream_def function for account stream
@@ -38,13 +40,13 @@ class TestStreamDef(unittest.TestCase):
         stream_response = get_stream_def(mock_stream_name, mock_schema, mock_stream_metadata, mock_pks, mock_replication_key)
 
         # Verify top-level breadcrum is available
-        self.assertEquals(stream_response.get('metadata')[0].get('breadcrumb'),())
-        self.assertEquals(stream_response.get('metadata')[0].get('metadata'),{'table-key-properties': ['Id'], 'forced-replication-method': 'INCREMENTAL', 'valid-replication-keys': 'LastModifiedTime', 'inclusion': 'available'})
+        self.assertEqual(stream_response.get('metadata')[0].get('breadcrumb'),())
+        self.assertEqual(stream_response.get('metadata')[0].get('metadata'),{'table-key-properties': ['Id'], 'forced-replication-method': 'INCREMENTAL', 'valid-replication-keys': 'LastModifiedTime', 'inclusion': 'available'})
 
         # Verify pks, replication_keys and automatic_keys in mock_stream_metadata must be automatic in metadata
         for field in stream_response.get('metadata'):
             if field.get('breadcrumb') in [('properties', 'Id'),('properties', 'LastModifiedTime'),('properties', 'CurrencyCode')]:
-                self.assertEquals(field.get('metadata').get('inclusion'),'automatic')
+                self.assertEqual(field.get('metadata').get('inclusion'),'automatic')
             if field.get('breadcrumb') == ('properties', 'CurrencyCode'):
                 # verify fieldExclusions
-                self.assertEquals(field.get('metadata').get('fieldExclusions'),[['properties','BidMatchType'],['properties','DeviceOS'],['properties','Goal'],['properties','GoalType'],['properties','TopVsOther']])
+                self.assertEqual(field.get('metadata').get('fieldExclusions'),[['properties','BidMatchType'],['properties','DeviceOS'],['properties','Goal'],['properties','GoalType'],['properties','TopVsOther']])


### PR DESCRIPTION
# Description of change
This PR extends the tap’s discovery/catalog metadata to include a parent-tap-stream-id for core object streams and report streams, and updates tests/CI to keep the backoff-related unit tests fast and move CI to Python 3.12.

Changes:

- Add parent-tap-stream-id into discovered stream metadata (core objects and reports) via a new parent_stream_id parameter to get_stream_def.
- Improve report sync behavior by surfacing and handling NoMeasureSelected and invalid field-selection cases with dedicated exceptions.
- Speed up backoff-related unit tests by patching backoff’s internal datetime and mocking time.sleep; update CircleCI Python version and dependency pins.
[SAC-28815](https://qlik-dev.atlassian.net/browse/SAC-28815)

# Manual QA steps
 - [x]  Discovery: running
 - [x]  Sync: running
 - [x]  Unit Tests: running
 - [ ]  Integration test: Not Tested
 
# Risks
 - The metadata fields are non-intrusive and only takes effect when explicitly present in the metadata.
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
