### PR TITLE
Add UserLocationPerformanceReport to REPORT_WHITELIST

### DIFF
--- a/tap_bing_ads/reports.py
+++ b/tap_bing_ads/reports.py
@@ -8,13 +8,15 @@ REPORT_WHITELIST = [
     'CampaignPerformanceReport',
     'GoalsAndFunnelsReport',
     'AudiencePerformanceReport',
-    'AdExtensionDetailReport'
+    'AdExtensionDetailReport',
+    'UserLocationPerformanceReport'
 ]
 
 REPORT_REQUIRED_FIELDS = ['_sdc_report_datetime', 'AccountId', 'TimePeriod']
 
 REPORT_SPECIFIC_REQUIRED_FIELDS = {
     'GeographicPerformanceReport': ['AccountName'],
+    'UserLocationPerformanceReport': ['AccountName'],
     'AgeGenderDemographicReport': [
         'AccountName',
         'AdGroupName',


### PR DESCRIPTION
Microsoft Advertising's UserLocationPerformanceReport returns the user's physical location (IP-derived) at click time, distinct from the broader GeographicPerformanceReport which can include search-intent location.

The report type is already exposed via the WSDL; this patch just allows the tap's dynamic stream-discovery to surface it as a Singer stream. Stream id will be 'user_location_performance_report'.

REPORT_SPECIFIC_REQUIRED_FIELDS gets a parallel entry to mirror GeographicPerformanceReport's AccountName requirement.

# Description of change
(write a short description or paste a link to JIRA)

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
