### PR TITLE
PR 2 - [SAC-31344] - Import error fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,9 @@ celerybeat-schedule
 venv/
 ENV/
 
+# temporary
+tmp/
+
 # Spyder project settings
 .spyderproject
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.4.0
   * Metadata fields updated for parent streams [#123](https://github.com/singer-io/tap-bing-ads/pull/123)
+  * Pin `setuptools==75.8.2` to restore `pkg_resources` availability for `bingads==13.0.11.1`, which imports it at module load to locate bundled WSDL files. `setuptools` removed `pkg_resources` in v82, causing a `ModuleNotFoundError` on Python 3.11 images that ship without it.
 
 ## 2.3.2
   * Dependency upgrades [#119](https://github.com/singer-io/tap-bing-ads/pull/119)

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,11 @@ setup(
         'requests==2.34.2',
         'singer-python==6.8.0',
         'backoff==2.2.1',
+        # bingads 13.0.11.1 imports pkg_resources at module load to locate bundled WSDL files.
+        # pkg_resources was removed from setuptools in v82, so pin to a specific version below
+        # that threshold to keep it available until the SDK is upgraded to a version that no
+        # longer needs it.
+        'setuptools==75.8.2',
     ],
     extras_require={
         'test': [

--- a/setup.py
+++ b/setup.py
@@ -15,14 +15,14 @@ setup(
         # Seems that suds-community is now the reference for 13.0.11.1 so we can install it now with the removal of use_2to3
         # https://github.com/BingAds/BingAds-Python-SDK/pull/192
         'bingads==13.0.11.1',
-        'requests==2.34.2',
+        'requests==2.32.4',
         'singer-python==6.8.0',
         'backoff==2.2.1',
         # bingads 13.0.11.1 imports pkg_resources at module load to locate bundled WSDL files.
         # pkg_resources was removed from setuptools in v82, so pin to a specific version below
         # that threshold to keep it available until the SDK is upgraded to a version that no
         # longer needs it.
-        'setuptools==75.8.2',
+        'setuptools==75.3.4',
     ],
     extras_require={
         'test': [

--- a/tests/base.py
+++ b/tests/base.py
@@ -72,8 +72,8 @@ class BingAdsBaseTest(BaseCase):
         return_value = {
             # 'start_date': '2020-10-01T00:00:00Z',  # original start_date
             'start_date': self.start_date,
-            'customer_id': '163875182',
-            'account_ids': '163078754,140168565,71086605',
+            'customer_id': os.getenv('TAP_BING_ADS_CUSTOMER_ID'),
+            'account_ids': os.getenv('TAP_BING_ADS_ACCOUNT_IDS'),
             # 'conversion_window': '-15',  # advanced option
         }
         # cid=42183085 aid=71086605  uid=71069166 (RJMetrics)
@@ -200,7 +200,9 @@ class BingAdsBaseTest(BaseCase):
         missing_envs = [x for x in ['TAP_BING_ADS_OAUTH_CLIENT_ID',
                                     'TAP_BING_ADS_OAUTH_CLIENT_SECRET',
                                     'TAP_BING_ADS_REFRESH_TOKEN',
-                                    'TAP_BING_ADS_DEVELOPER_TOKEN']
+                                    'TAP_BING_ADS_DEVELOPER_TOKEN',
+                                    'TAP_BING_ADS_CUSTOMER_ID',
+                                    'TAP_BING_ADS_ACCOUNT_IDS']
                         if os.getenv(x) is None]
         if missing_envs:
             raise Exception("set environment variables")

--- a/tests/base_new_framework.py
+++ b/tests/base_new_framework.py
@@ -42,8 +42,8 @@ class BingAdsBaseTest(BaseCase):
         """Configuration properties required for the tap."""
         return_value = {
             'start_date': self.start_date,
-            'customer_id': '163875182',
-            'account_ids': '163078754,140168565,71086605',
+            'customer_id': os.getenv('TAP_BING_ADS_CUSTOMER_ID'),
+            'account_ids': os.getenv('TAP_BING_ADS_ACCOUNT_IDS'),
             # 'conversion_window': '-15',  # advanced option
         }
         # cid=42183085 aid=71086605  uid=71069166 (RJMetrics)
@@ -141,6 +141,7 @@ class BingAdsBaseTest(BaseCase):
         missing_envs = [
             x for x in ['TAP_BING_ADS_OAUTH_CLIENT_ID', 'TAP_BING_ADS_OAUTH_CLIENT_SECRET',
                         'TAP_BING_ADS_REFRESH_TOKEN', 'TAP_BING_ADS_DEVELOPER_TOKEN',
+                        'TAP_BING_ADS_CUSTOMER_ID', 'TAP_BING_ADS_ACCOUNT_IDS',
             ] if os.getenv(x) is None
         ]
 


### PR DESCRIPTION
# Description of change
Ticket: https://qlik-dev.atlassian.net/browse/SAC-31344

**fix: pin setuptools==75.8.2 to restore pkg_resources for bingads SDK**

> `bingads==13.0.11.1` imports `pkg_resources` at module load to locate its bundled WSDL files. `setuptools` removed `pkg_resources` in v82, causing a `ModuleNotFoundError` on Python 3.11 images that ship without it — crashing discovery/check jobs before any real work is done.
> 
> Pins `setuptools==75.8.2` (a stable release below the v82 threshold) to keep `pkg_resources` available until the SDK is upgraded to a version that no longer depends on it.


# Manual QA steps
 - [x]  Discovery: running
 - [ ]  Sync: Not Tested
 - [ ]  Unit Tests: Not Tested
 - [ ]  Integration test: Not Tested

# Rollback steps
 - revert this branch

